### PR TITLE
Refactor layout cache to split nav and site-meta keys

### DIFF
--- a/src/lib/cache/cache.ts
+++ b/src/lib/cache/cache.ts
@@ -5,5 +5,5 @@ export const cacheManager = new UpstashCache({
 	url: env.UPSTASH_REDIS_REST_URL!,
 	token: env.UPSTASH_REDIS_REST_TOKEN!,
 	prefix: 'payload:',
-	ttl: 3600
+	ttl: 86400
 });

--- a/src/routes/(site)/articles/[slug]/+page.server.ts
+++ b/src/routes/(site)/articles/[slug]/+page.server.ts
@@ -1,14 +1,41 @@
 import { getPayloadSDK } from '$lib/payload.server';
+import { cacheManager } from '$lib/cache/cache';
+import type { Post } from '$lib/types/payload-types';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+
+const ARTICLE_CACHE_STALE_THRESHOLD_S = 300; // 5 minutes
+
+async function fetchArticleByIdFromCMS(articleId: number | string): Promise<Post | null> {
+	const sdk = getPayloadSDK();
+	return sdk.findByID({
+		collection: 'posts',
+		id: articleId,
+		disableErrors: true
+	});
+}
+
+async function refreshArticleInBackground(articleId: number | string, cacheKey: string): Promise<void> {
+	try {
+		const article = await fetchArticleByIdFromCMS(articleId);
+		if (article) {
+			await cacheManager.set(cacheKey, article);
+		}
+	} catch (err) {
+		console.error('[article-cache] Background refresh failed:', err);
+	}
+}
 
 export const load: PageServerLoad = async ({ fetch, url, params, request }) => {
 	const sdk = getPayloadSDK(fetch, request);
 	const slug = params.slug;
 
-	const post = await sdk.find({
+	const postLookup = await sdk.find({
 		collection: 'posts',
 		limit: 1,
+		select: {
+			id: true
+		},
 		where: {
 			and: [
 				{
@@ -23,11 +50,34 @@ export const load: PageServerLoad = async ({ fetch, url, params, request }) => {
 		}
 	});
 
-	if (post.totalDocs === 0) {
+	if (postLookup.totalDocs === 0) {
 		throw error(404, 'Article not found');
 	}
 
-	const doc = post.docs[0];
+	const articleId = postLookup.docs[0]?.id;
+	if (articleId == null) {
+		throw error(500, 'Article lookup missing id');
+	}
+
+	const articleCacheKey = cacheManager.createKey(`article:${articleId}`);
+	const cachedArticle = (await cacheManager.get(articleCacheKey)) as Post | null;
+
+	let doc: Post;
+	if (cachedArticle) {
+		doc = cachedArticle;
+		const isStale = await cacheManager.isCacheStale(articleCacheKey, ARTICLE_CACHE_STALE_THRESHOLD_S);
+		if (isStale) {
+			refreshArticleInBackground(articleId, articleCacheKey).catch(() => {});
+		}
+	} else {
+		const freshArticle = await fetchArticleByIdFromCMS(articleId);
+		if (!freshArticle) {
+			throw error(404, 'Article not found');
+		}
+		doc = freshArticle;
+		await cacheManager.set(articleCacheKey, doc);
+	}
+
 	const meta = doc.meta
 		? { ...doc.meta, canonicalURL: `${url.origin}/articles/${slug}` }
 		: { canonicalURL: `${url.origin}/articles/${slug}` };

--- a/src/routes/(site)/articles/[slug]/+page.server.ts
+++ b/src/routes/(site)/articles/[slug]/+page.server.ts
@@ -6,6 +6,10 @@ import type { PageServerLoad } from './$types';
 
 const ARTICLE_CACHE_STALE_THRESHOLD_S = 300; // 5 minutes
 
+function isPublishedArticle(article: Post | null | undefined): article is Post {
+	return article?._status === 'published';
+}
+
 async function fetchArticleByIdFromCMS(articleId: number | string): Promise<Post | null> {
 	const sdk = getPayloadSDK();
 	return sdk.findByID({
@@ -18,7 +22,7 @@ async function fetchArticleByIdFromCMS(articleId: number | string): Promise<Post
 async function refreshArticleInBackground(articleId: number | string, cacheKey: string): Promise<void> {
 	try {
 		const article = await fetchArticleByIdFromCMS(articleId);
-		if (article) {
+		if (isPublishedArticle(article)) {
 			await cacheManager.set(cacheKey, article);
 		}
 	} catch (err) {
@@ -63,7 +67,7 @@ export const load: PageServerLoad = async ({ fetch, url, params, request }) => {
 	const cachedArticle = (await cacheManager.get(articleCacheKey)) as Post | null;
 
 	let doc: Post;
-	if (cachedArticle) {
+	if (isPublishedArticle(cachedArticle)) {
 		doc = cachedArticle;
 		const isStale = await cacheManager.isCacheStale(articleCacheKey, ARTICLE_CACHE_STALE_THRESHOLD_S);
 		if (isStale) {
@@ -71,11 +75,11 @@ export const load: PageServerLoad = async ({ fetch, url, params, request }) => {
 		}
 	} else {
 		const freshArticle = await fetchArticleByIdFromCMS(articleId);
-		if (!freshArticle) {
+		if (!isPublishedArticle(freshArticle)) {
 			throw error(404, 'Article not found');
 		}
 		doc = freshArticle;
-		await cacheManager.set(articleCacheKey, doc);
+		await cacheManager.set(articleCacheKey, freshArticle);
 	}
 
 	const meta = doc.meta

--- a/src/routes/api/layout-data/+server.ts
+++ b/src/routes/api/layout-data/+server.ts
@@ -4,7 +4,8 @@ import type { SiteMeta, SiteNavigation } from '$lib/types/payload-types';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-const CACHE_KEY = 'layout:data';
+const NAV_CACHE_KEY = 'layout:nav';
+const META_CACHE_KEY = 'layout:meta';
 const STALE_THRESHOLD_S = 300; // 5 minutes
 
 export interface LayoutApiResponse {
@@ -12,13 +13,10 @@ export interface LayoutApiResponse {
 	siteMeta: SiteMeta;
 }
 
-async function fetchFromCMS(fetchFn: typeof globalThis.fetch): Promise<LayoutApiResponse> {
+async function fetchNavigationFromCMS(fetchFn: typeof globalThis.fetch): Promise<SiteNavigation> {
 	const sdk = getPayloadSDK(fetchFn);
 
-	const [nav, siteMeta] = await Promise.all([
-		sdk.findGlobal({ slug: 'site-navigation', depth: 1, draft: true }),
-		sdk.findGlobal({ slug: 'site-meta', depth: 1 })
-	]);
+	const nav = await sdk.findGlobal({ slug: 'site-navigation', depth: 1, draft: true });
 
 	const navItems = nav.navItems
 		? [...nav.navItems]
@@ -33,34 +31,98 @@ async function fetchFromCMS(fetchFn: typeof globalThis.fetch): Promise<LayoutApi
 
 	const navigation: SiteNavigation = { ...nav, navItems };
 
-	return { navigation, siteMeta };
+	return navigation;
 }
 
-async function refreshInBackground(fetchFn: typeof globalThis.fetch): Promise<void> {
+async function fetchSiteMetaFromCMS(fetchFn: typeof globalThis.fetch): Promise<SiteMeta> {
+	const sdk = getPayloadSDK(fetchFn);
+	return sdk.findGlobal({ slug: 'site-meta', depth: 1 });
+}
+
+async function refreshNavigationInBackground(fetchFn: typeof globalThis.fetch): Promise<void> {
 	try {
-		const data = await fetchFromCMS(fetchFn);
-		await cacheManager.set(cacheManager.createKey(CACHE_KEY), data);
+		const navigation = await fetchNavigationFromCMS(fetchFn);
+		await cacheManager.set(cacheManager.createKey(NAV_CACHE_KEY), navigation);
 	} catch (err) {
-		console.error('[layout-data] Background refresh failed:', err);
+		console.error('[layout-data] Navigation background refresh failed:', err);
+	}
+}
+
+async function refreshSiteMetaInBackground(fetchFn: typeof globalThis.fetch): Promise<void> {
+	try {
+		const siteMeta = await fetchSiteMetaFromCMS(fetchFn);
+		await cacheManager.set(cacheManager.createKey(META_CACHE_KEY), siteMeta);
+	} catch (err) {
+		console.error('[layout-data] Site meta background refresh failed:', err);
 	}
 }
 
 export const GET: RequestHandler = async ({ fetch }) => {
-	const cacheKey = cacheManager.createKey(CACHE_KEY);
+	const navCacheKey = cacheManager.createKey(NAV_CACHE_KEY);
+	const metaCacheKey = cacheManager.createKey(META_CACHE_KEY);
 
-	const cached = await cacheManager.get(cacheKey);
-	if (cached) {
-		const isStale = await cacheManager.isCacheStale(cacheKey, STALE_THRESHOLD_S);
-		if (isStale) {
-			// Serve immediately, refresh in background
-			refreshInBackground(fetch).catch(() => {});
+	const [cachedNavigation, cachedSiteMeta] = await Promise.all([
+		cacheManager.get(navCacheKey),
+		cacheManager.get(metaCacheKey)
+	]);
+
+	if (cachedNavigation && cachedSiteMeta) {
+		const [isNavStale, isMetaStale] = await Promise.all([
+			cacheManager.isCacheStale(navCacheKey, STALE_THRESHOLD_S),
+			cacheManager.isCacheStale(metaCacheKey, STALE_THRESHOLD_S)
+		]);
+
+		if (isNavStale) {
+			// Serve immediately, refresh navigation in background
+			refreshNavigationInBackground(fetch).catch(() => {});
 		}
-		return json(cached as LayoutApiResponse, { headers: { 'X-Cache': 'HIT' } });
+
+		if (isMetaStale) {
+			// Serve immediately, refresh site meta in background
+			refreshSiteMetaInBackground(fetch).catch(() => {});
+		}
+
+		return json(
+			{
+				navigation: cachedNavigation as SiteNavigation,
+				siteMeta: cachedSiteMeta as SiteMeta
+			},
+			{ headers: { 'X-Cache': 'HIT' } }
+		);
 	}
 
-	// Cache miss – fetch fresh
-	const data = await fetchFromCMS(fetch);
-	await cacheManager.set(cacheKey, data);
+	if (cachedNavigation) {
+		const isNavStale = await cacheManager.isCacheStale(navCacheKey, STALE_THRESHOLD_S);
+		if (isNavStale) {
+			refreshNavigationInBackground(fetch).catch(() => {});
+		}
+	}
 
-	return json(data, { headers: { 'X-Cache': 'MISS' } });
+	if (cachedSiteMeta) {
+		const isMetaStale = await cacheManager.isCacheStale(metaCacheKey, STALE_THRESHOLD_S);
+		if (isMetaStale) {
+			refreshSiteMetaInBackground(fetch).catch(() => {});
+		}
+	}
+
+	// Partial/full cache miss – fetch only missing pieces fresh
+	const [navigation, siteMeta] = await Promise.all([
+		cachedNavigation
+			? Promise.resolve(cachedNavigation as SiteNavigation)
+			: fetchNavigationFromCMS(fetch),
+		cachedSiteMeta ? Promise.resolve(cachedSiteMeta as SiteMeta) : fetchSiteMetaFromCMS(fetch)
+	]);
+
+	const writes: Promise<void>[] = [];
+	if (!cachedNavigation) {
+		writes.push(cacheManager.set(navCacheKey, navigation));
+	}
+	if (!cachedSiteMeta) {
+		writes.push(cacheManager.set(metaCacheKey, siteMeta));
+	}
+	if (writes.length > 0) {
+		await Promise.all(writes);
+	}
+
+	return json({ navigation, siteMeta }, { headers: { 'X-Cache': 'MISS' } });
 };

--- a/src/routes/api/layout-data/+server.ts
+++ b/src/routes/api/layout-data/+server.ts
@@ -13,8 +13,8 @@ export interface LayoutApiResponse {
 	siteMeta: SiteMeta;
 }
 
-async function fetchNavigationFromCMS(fetchFn: typeof globalThis.fetch): Promise<SiteNavigation> {
-	const sdk = getPayloadSDK(fetchFn);
+async function fetchNavigationFromCMS(): Promise<SiteNavigation> {
+	const sdk = getPayloadSDK();
 
 	const nav = await sdk.findGlobal({ slug: 'site-navigation', depth: 1, draft: true });
 
@@ -34,30 +34,30 @@ async function fetchNavigationFromCMS(fetchFn: typeof globalThis.fetch): Promise
 	return navigation;
 }
 
-async function fetchSiteMetaFromCMS(fetchFn: typeof globalThis.fetch): Promise<SiteMeta> {
-	const sdk = getPayloadSDK(fetchFn);
+async function fetchSiteMetaFromCMS(): Promise<SiteMeta> {
+	const sdk = getPayloadSDK();
 	return sdk.findGlobal({ slug: 'site-meta', depth: 1 });
 }
 
-async function refreshNavigationInBackground(fetchFn: typeof globalThis.fetch): Promise<void> {
+async function refreshNavigationInBackground(): Promise<void> {
 	try {
-		const navigation = await fetchNavigationFromCMS(fetchFn);
+		const navigation = await fetchNavigationFromCMS();
 		await cacheManager.set(cacheManager.createKey(NAV_CACHE_KEY), navigation);
 	} catch (err) {
 		console.error('[layout-data] Navigation background refresh failed:', err);
 	}
 }
 
-async function refreshSiteMetaInBackground(fetchFn: typeof globalThis.fetch): Promise<void> {
+async function refreshSiteMetaInBackground(): Promise<void> {
 	try {
-		const siteMeta = await fetchSiteMetaFromCMS(fetchFn);
+		const siteMeta = await fetchSiteMetaFromCMS();
 		await cacheManager.set(cacheManager.createKey(META_CACHE_KEY), siteMeta);
 	} catch (err) {
 		console.error('[layout-data] Site meta background refresh failed:', err);
 	}
 }
 
-export const GET: RequestHandler = async ({ fetch }) => {
+export const GET: RequestHandler = async () => {
 	const navCacheKey = cacheManager.createKey(NAV_CACHE_KEY);
 	const metaCacheKey = cacheManager.createKey(META_CACHE_KEY);
 
@@ -74,12 +74,12 @@ export const GET: RequestHandler = async ({ fetch }) => {
 
 		if (isNavStale) {
 			// Serve immediately, refresh navigation in background
-			refreshNavigationInBackground(fetch).catch(() => {});
+			refreshNavigationInBackground().catch(() => {});
 		}
 
 		if (isMetaStale) {
 			// Serve immediately, refresh site meta in background
-			refreshSiteMetaInBackground(fetch).catch(() => {});
+			refreshSiteMetaInBackground().catch(() => {});
 		}
 
 		return json(
@@ -94,14 +94,14 @@ export const GET: RequestHandler = async ({ fetch }) => {
 	if (cachedNavigation) {
 		const isNavStale = await cacheManager.isCacheStale(navCacheKey, STALE_THRESHOLD_S);
 		if (isNavStale) {
-			refreshNavigationInBackground(fetch).catch(() => {});
+			refreshNavigationInBackground().catch(() => {});
 		}
 	}
 
 	if (cachedSiteMeta) {
 		const isMetaStale = await cacheManager.isCacheStale(metaCacheKey, STALE_THRESHOLD_S);
 		if (isMetaStale) {
-			refreshSiteMetaInBackground(fetch).catch(() => {});
+			refreshSiteMetaInBackground().catch(() => {});
 		}
 	}
 
@@ -109,8 +109,8 @@ export const GET: RequestHandler = async ({ fetch }) => {
 	const [navigation, siteMeta] = await Promise.all([
 		cachedNavigation
 			? Promise.resolve(cachedNavigation as SiteNavigation)
-			: fetchNavigationFromCMS(fetch),
-		cachedSiteMeta ? Promise.resolve(cachedSiteMeta as SiteMeta) : fetchSiteMetaFromCMS(fetch)
+			: fetchNavigationFromCMS(),
+		cachedSiteMeta ? Promise.resolve(cachedSiteMeta as SiteMeta) : fetchSiteMetaFromCMS()
 	]);
 
 	const writes: Promise<void>[] = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactored `/api/layout-data` cache handling to store/retrieve navigation and site meta under separate Upstash keys.
- Replaced the single `layout:data` cache key with:
  - `layout:nav` (stored as `payload:layout:nav` via cache prefix)
  - `layout:meta` (stored as `payload:layout:meta` via cache prefix)
- Added singular article caching in article detail load flow using key format `payload:article:{id}`.
- Hardened article caching so only `_status: "published"` articles are ever written to Redis.
- Kept existing API/page response shapes unchanged.
- Added a follow-up hotfix for a server-side CORS regression observed on `/api/layout-data` when cache misses triggered CMS fetches.
- Increased cache TTL from 1 hour to 1 day for `cacheManager` writes.

## Implementation details
### Layout key separation
- Introduced separate CMS fetchers for layout:
  - `fetchNavigationFromCMS()`
  - `fetchSiteMetaFromCMS()`
- Introduced separate background refresh paths:
  - `refreshNavigationInBackground()`
  - `refreshSiteMetaInBackground()`
- Updated `/api/layout-data` GET logic to:
  - Read both keys in parallel
  - Return HIT when both are present
  - Refresh stale nav/meta independently in background
  - On partial misses, fetch only missing piece(s), then populate only missing key(s)

### Singular article caching (`payload:article:{id}`)
- Updated `src/routes/(site)/articles/[slug]/+page.server.ts`:
  - First resolves article `id` from the existing published-by-slug lookup.
  - Builds cache key with `cacheManager.createKey(`article:${id}`)` → `payload:article:{id}`.
  - Reads cached article first.
  - Applies stale-while-revalidate behavior with stale threshold (`300s`):
    - fresh cache: return cached article
    - stale cache: return cached article and refresh in background
    - miss: fetch by ID from CMS, store in Redis, return fresh article

### Published-only cache guard
- Added `isPublishedArticle()` guard and enforced it on all article cache writes:
  - Initial cache fill on miss writes only when `_status === "published"`.
  - Background refresh writes only when `_status === "published"`.
- Added read-side hardening: cached entries that are not published are ignored and treated as misses.

### Hotfix (CORS regression)
- Root cause: `/api/layout-data` used SvelteKit request-scoped `fetch` for external Payload SDK calls during cache miss/background refresh, which can enforce browser-like CORS checks in this context.
- Fix: switched `layout-data` CMS calls to use `getPayloadSDK()` without passing request-scoped fetch, so server-to-server fetch uses the SDK's default/global fetch path.

### TTL update
- Updated `src/lib/cache/cache.ts` default Upstash TTL from `3600` to `86400` seconds.
- Effective Redis key expiry for these entries is now 24 hours.

## Validation
- `pnpm check` ✅ (0 errors)
- Existing unrelated warnings in `board-games/+page.svelte` remain unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1f4f07b-80da-4273-98c0-cd65a5b5cbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1f4f07b-80da-4273-98c0-cd65a5b5cbf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

