### PR TITLE
Add board game roulette picker

### DIFF
--- a/src/routes/(site)/board-games/+page.server.ts
+++ b/src/routes/(site)/board-games/+page.server.ts
@@ -3,7 +3,6 @@ import type { PageServerLoad } from './$types';
 
 async function fetchBGGCollection(
 	username: string,
-	stats: 0 | 1,
 	retryCount = 0
 ): Promise<{ games: unknown[]; total: number; error?: string }> {
 	const maxRetries = 5;
@@ -20,7 +19,7 @@ async function fetchBGGCollection(
 			};
 		}
 
-		const url = `https://cms.itsmillertime.dev/api/bgg/collection?username=${encodeURIComponent(username)}&stats=${stats}`;
+		const url = `https://cms.itsmillertime.dev/api/bgg/collection?username=${encodeURIComponent(username)}&stats=1`;
 		console.log('Fetching BGG collection:', url);
 
 		const response = await fetch(url);
@@ -34,7 +33,7 @@ async function fetchBGGCollection(
 					`Request queued (202), retrying in ${retryDelay}ms... (attempt ${retryCount + 1}/${maxRetries})`
 				);
 				await new Promise((resolve) => setTimeout(resolve, retryDelay));
-				return fetchBGGCollection(username, stats, retryCount + 1);
+				return fetchBGGCollection(username, retryCount + 1);
 			} else {
 				return {
 					games: [],
@@ -81,13 +80,10 @@ export const load: PageServerLoad = async ({ url, parent }) => {
 	const { session } = await parent();
 	const defaultUsername = session?.user?.bggUsername ?? 'moose517';
 	const username = url.searchParams.get('username') || defaultUsername;
-	const statsParam = url.searchParams.get('stats');
-	const stats: 0 | 1 = statsParam === '1' ? 1 : 0;
-	const result = await fetchBGGCollection(username, stats);
+	const result = await fetchBGGCollection(username);
 
 	return {
 		username,
-		stats,
 		games: result.games,
 		total: result.total,
 		error: result.error

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1040,7 +1040,7 @@
 		gap: 0.85rem 0;
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.35rem;
+		padding: 1rem 0 1.35rem;
 		border: 7px solid #5f2f19;
 		background:
 			repeating-linear-gradient(
@@ -1097,7 +1097,7 @@
 		position: absolute;
 		z-index: 20;
 		left: 50%;
-		bottom: calc(var(--shelf-board-height) + 100% - var(--shelf-row-height) + 0.55rem);
+		bottom: calc(100% + 0.55rem);
 		transform: translate(-50%, 0);
 		width: min(15.5rem, 78vw);
 		padding: 0.8rem 0.9rem;

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -33,6 +33,8 @@
 	let highlightedSpinIndex = $state(0);
 	let spinTick = $state(0);
 	let spinTimeout: ReturnType<typeof setTimeout> | null = null;
+	let activeGamePopover: HTMLElement | null = null;
+	let popoverHideTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	const SPIN_VISIBLE_RADIUS = 2;
 	const SPIN_MIN_TICKS = 28;
@@ -50,6 +52,7 @@
 		playerCountFilter = 'all';
 		playtimeFilter = 'all';
 		clearSpinTimer();
+		closeActiveGamePopover();
 		isSpinning = false;
 		spinGames = [];
 		pickedGame = null;
@@ -130,6 +133,7 @@
 	$effect(() => {
 		return () => {
 			clearSpinTimer();
+			clearPopoverHideTimer();
 		};
 	});
 
@@ -250,6 +254,47 @@
 
 	function getGamePopoverId(game: BggGame, index: number): string {
 		return `game-popover-${game.id}-${index}`;
+	}
+
+	function getGamePopoverAnchor(game: BggGame, index: number): string {
+		return `--game-popover-${game.id}-${index}`;
+	}
+
+	function clearPopoverHideTimer() {
+		if (popoverHideTimeout) {
+			clearTimeout(popoverHideTimeout);
+			popoverHideTimeout = null;
+		}
+	}
+
+	function closeActiveGamePopover() {
+		clearPopoverHideTimer();
+		if (activeGamePopover?.matches(':popover-open')) {
+			activeGamePopover.hidePopover();
+		}
+		activeGamePopover = null;
+	}
+
+	function showGamePopover(popoverId: string) {
+		clearPopoverHideTimer();
+		const popover = document.getElementById(popoverId);
+		if (!popover) return;
+
+		if (activeGamePopover && activeGamePopover !== popover) {
+			closeActiveGamePopover();
+		}
+
+		if (!popover.matches(':popover-open')) {
+			popover.showPopover();
+		}
+		activeGamePopover = popover;
+	}
+
+	function queueHideGamePopover() {
+		clearPopoverHideTimer();
+		popoverHideTimeout = setTimeout(() => {
+			closeActiveGamePopover();
+		}, 120);
 	}
 </script>
 
@@ -456,85 +501,96 @@
 					</div>
 				{/if}
 			</section>
-		{:else}
-			<div class="games-flex">
-				{#if displayedGames.length === 0 && data.games.length > 0}
-					<p class="filter-empty font-oswald">No games match this filter.</p>
-				{/if}
-				{#each displayedGames as game, i (`${game.id}-${i}`)}
-					{@const g = game as BggGame}
-					{@const popoverId = getGamePopoverId(g, i)}
-					<div class="game-card-wrap">
-						<div
-							id={popoverId}
-							class="game-popover font-oswald"
-							popover="auto"
-							role="dialog"
-							aria-label={g.name ? `${g.name} details` : 'Game details'}
-						>
-							<p class="game-popover-title">{g.name ?? 'Game'}</p>
-							<dl class="game-popover-dl">
-								<dt>Your plays</dt>
-								<dd>{g.numplays ?? '—'}</dd>
-								<dt>Players</dt>
-								<dd>
-									{#if g.stats?.minplayers != null && g.stats.maxplayers != null}
-										{g.stats.minplayers}–{g.stats.maxplayers}
-									{:else}
-										—
-									{/if}
-								</dd>
-								<dt>Play time</dt>
-								<dd>{formatPlayTime(g)}</dd>
-								<dt>Avg rating</dt>
-								<dd>
-									{formatAvg(g.stats?.rating?.average)}
-									{#if g.stats?.rating?.usersrated != null}
-										<span class="game-popover-sub">
-											({g.stats.rating.usersrated.toLocaleString()} votes)
-										</span>
-									{/if}
-								</dd>
-							</dl>
-							<a
-								class="game-popover-link lookup-btn font-oswald"
-								href="https://boardgamegeek.com/boardgame/{g.id}"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Open on BGG
-							</a>
-						</div>
-						<button
-							type="button"
-							class="game-card"
-							aria-haspopup="dialog"
-							popovertarget={popoverId}
-						>
-							{#if g.thumbnail}
-								<img src={g.image} alt={g.name ?? ''} class="game-image" loading="lazy" />
-							{:else}
-								<div class="game-image-placeholder">
-									<span>No Image</span>
-								</div>
-							{/if}
-						</button>
-					</div>
-				{/each}
-			</div>
 		{/if}
 	</div>
 </Panel>
 
+{#if !isSpinning && !pickedGame && !data.error && data.games.length > 0}
+	<div class="games-flex">
+		{#if displayedGames.length === 0}
+			<p class="filter-empty font-oswald">No games match this filter.</p>
+		{/if}
+		{#each displayedGames as game, i (`${game.id}-${i}`)}
+			{@const g = game as BggGame}
+			{@const popoverId = getGamePopoverId(g, i)}
+			{@const popoverAnchor = getGamePopoverAnchor(g, i)}
+			<div class="game-card-wrap">
+				<div
+					id={popoverId}
+					class="game-popover font-oswald"
+					style={`--popover-anchor: ${popoverAnchor}`}
+					popover="auto"
+					role="dialog"
+					aria-label={g.name ? `${g.name} details` : 'Game details'}
+					onmouseenter={clearPopoverHideTimer}
+					onmouseleave={queueHideGamePopover}
+				>
+					<p class="game-popover-title">{g.name ?? 'Game'}</p>
+					<dl class="game-popover-dl">
+						<dt>Your plays</dt>
+						<dd>{g.numplays ?? '—'}</dd>
+						<dt>Players</dt>
+						<dd>
+							{#if g.stats?.minplayers != null && g.stats.maxplayers != null}
+								{g.stats.minplayers}–{g.stats.maxplayers}
+							{:else}
+								—
+							{/if}
+						</dd>
+						<dt>Play time</dt>
+						<dd>{formatPlayTime(g)}</dd>
+						<dt>Avg rating</dt>
+						<dd>
+							{formatAvg(g.stats?.rating?.average)}
+							{#if g.stats?.rating?.usersrated != null}
+								<span class="game-popover-sub">
+									({g.stats.rating.usersrated.toLocaleString()} votes)
+								</span>
+							{/if}
+						</dd>
+					</dl>
+					<a
+						class="game-popover-link lookup-btn font-oswald"
+						href="https://boardgamegeek.com/boardgame/{g.id}"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Open on BGG
+					</a>
+				</div>
+				<button
+					type="button"
+					class="game-card"
+					style={`anchor-name: ${popoverAnchor}`}
+					aria-haspopup="dialog"
+					popovertarget={popoverId}
+					onmouseenter={() => showGamePopover(popoverId)}
+					onmouseleave={queueHideGamePopover}
+					onfocus={() => showGamePopover(popoverId)}
+					onblur={queueHideGamePopover}
+				>
+					{#if g.thumbnail}
+						<img src={g.image} alt={g.name ?? ''} class="game-image" loading="lazy" />
+					{:else}
+						<div class="game-image-placeholder">
+							<span>No Image</span>
+						</div>
+					{/if}
+				</button>
+			</div>
+		{/each}
+	</div>
+{/if}
+
 <style>
 	.board-games-page {
-		padding: clamp(1rem, 1rem + 1vw, 2rem);
+		padding: clamp(0.9rem, 0.8rem + 0.8vw, 1.5rem);
 	}
 
 	.page-header {
 		text-align: center;
-		margin-bottom: 3rem;
-		padding-bottom: 2rem;
+		margin-bottom: 1.25rem;
+		padding-bottom: 1rem;
 		border-bottom: 3px solid var(--color-primary-darker);
 	}
 
@@ -568,10 +624,10 @@
 		flex-wrap: wrap;
 		justify-content: center;
 		align-items: flex-end;
-		gap: 0.75rem 1rem;
+		gap: 0.65rem 0.85rem;
 		max-width: 68rem;
 		margin-inline: auto;
-		padding: 0.85rem 1rem;
+		padding: 0.75rem 0.85rem;
 		border: 1px solid var(--color-tertiary-lighter);
 		background: var(--color-white-lightest);
 	}
@@ -1074,6 +1130,10 @@
 	}
 
 	.game-popover {
+		position: absolute;
+		position-anchor: var(--popover-anchor);
+		position-area: top;
+		margin: 0 0 0.75rem;
 		width: min(15.5rem, 78vw);
 		max-width: calc(100vw - 2rem);
 		padding: 0.8rem 0.9rem;
@@ -1154,19 +1214,24 @@
 		width: var(--game-cover-width);
 		max-height: calc(var(--shelf-row-height) - var(--shelf-board-height) - 1rem);
 		flex-shrink: 0;
+		padding: 0;
 		text-decoration: none;
 		transition:
 			transform 0.2s ease,
 			box-shadow 0.2s ease,
 			filter 0.2s ease;
 		overflow: hidden;
+		appearance: none;
+		border: 0;
 		background: transparent;
 		box-shadow: 0 0.7rem 0.85rem rgb(0 0 0 / 0.22);
+		cursor: pointer;
 		transform-origin: bottom center;
 	}
 
 	.game-card:hover,
 	.game-card:focus-visible {
+		outline: 0;
 		transform: translateY(-8px) rotate(-1deg);
 		box-shadow: 0 0.85rem 1rem rgb(0 0 0 / 0.3);
 		filter: saturate(1.05);

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -998,7 +998,7 @@
 		border: clamp(0.75rem, 1.5vw, 1rem) solid #5f2f19;
 		background-color: #8b4723;
 		background-image: var(--wood-grain-texture);
-		background-size: 260px 120px;
+		background-size: 360px 270px;
 		box-shadow:
 			inset 0 0 0 3px rgb(255 235 190 / 0.12),
 			inset 0 0 2rem rgb(50 22 9 / 0.24),
@@ -1010,7 +1010,7 @@
 		--shelf-board-height: 2.35rem;
 		--shelf-row-gap: 1.15rem;
 		--shelf-row-height: clamp(13.25rem, 20vw, 15.75rem);
-		--wood-grain-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='120' viewBox='0 0 260 120'%3E%3Cg fill='none' stroke-linecap='round'%3E%3Cpath d='M-24 16 C22 5 56 27 102 15 S192 7 284 20' stroke='%23f3c987' stroke-opacity='.22' stroke-width='3'/%3E%3Cpath d='M-18 34 C42 24 76 46 132 33 S218 27 278 42' stroke='%23532513' stroke-opacity='.18' stroke-width='2'/%3E%3Cpath d='M-26 58 C32 46 66 68 118 56 S202 49 286 64' stroke='%23f8d697' stroke-opacity='.16' stroke-width='2.4'/%3E%3Cpath d='M-22 84 C46 74 92 98 152 84 S224 78 284 94' stroke='%23451f0f' stroke-opacity='.2' stroke-width='2.2'/%3E%3Cpath d='M-14 106 C34 96 72 116 126 106 S210 98 278 112' stroke='%23f0be75' stroke-opacity='.14' stroke-width='2'/%3E%3Cellipse cx='72' cy='63' rx='28' ry='9' stroke='%23451f0f' stroke-opacity='.17' stroke-width='2'/%3E%3Cellipse cx='72' cy='63' rx='13' ry='4' stroke='%23f7d28f' stroke-opacity='.13' stroke-width='1.5'/%3E%3Cellipse cx='190' cy='27' rx='20' ry='6' stroke='%23451f0f' stroke-opacity='.14' stroke-width='1.6'/%3E%3C/g%3E%3C/svg%3E");
+		--wood-grain-texture: url('https://openclipart.org/download/321589/woodgrain-pattern-2.svg');
 	}
 
 	.games-flex::before {
@@ -1019,7 +1019,6 @@
 		z-index: 0;
 		inset: var(--bookcase-padding-block) 0 1.35rem;
 		background:
-			var(--wood-grain-texture),
 			repeating-linear-gradient(
 				to bottom,
 				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
@@ -1034,10 +1033,12 @@
 					calc(var(--shelf-row-height) + 0.35rem),
 				transparent calc(var(--shelf-row-height) + 0.35rem)
 					calc(var(--shelf-row-height) + var(--shelf-row-gap))
-			);
+			),
+			var(--wood-grain-texture);
+		background-blend-mode: normal, multiply;
 		background-size:
-			260px 120px,
-			auto;
+			auto,
+			360px 270px;
 		pointer-events: none;
 	}
 

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -38,6 +38,7 @@
 	const SPIN_VISIBLE_RADIUS = 2;
 	const SPIN_MIN_TICKS = 28;
 	const SPIN_EXTRA_TICKS = 18;
+	const SPIN_SETTLE_DELAY_MS = 450;
 
 	$effect(() => {
 		lookupUsername = data.username;
@@ -174,24 +175,30 @@
 		});
 	}
 
-	function scheduleSpinTick(finalIndex: number, totalTicks: number) {
+	function scheduleSpinTick(totalTicks: number) {
 		const progress = spinTick / totalTicks;
 		const delay = 55 + Math.pow(progress, 3) * 190;
 
 		spinTimeout = setTimeout(() => {
 			if (spinGames.length === 0) return;
 
+			const nextIndex = (highlightedSpinIndex + 1) % spinGames.length;
+
 			spinTick += 1;
-			highlightedSpinIndex = (highlightedSpinIndex + 1) % spinGames.length;
+			highlightedSpinIndex = nextIndex;
 
 			if (spinTick >= totalTicks) {
+				const selectedGame = spinGames[nextIndex] ?? null;
 				clearSpinTimer();
-				isSpinning = false;
-				pickedGame = spinGames[finalIndex] ?? spinGames[highlightedSpinIndex] ?? null;
+				spinTimeout = setTimeout(() => {
+					spinTimeout = null;
+					isSpinning = false;
+					pickedGame = selectedGame;
+				}, SPIN_SETTLE_DELAY_MS);
 				return;
 			}
 
-			scheduleSpinTick(finalIndex, totalTicks);
+			scheduleSpinTick(totalTicks);
 		}, delay);
 	}
 
@@ -209,7 +216,7 @@
 		spinTick = 0;
 		pickedGame = null;
 		isSpinning = true;
-		scheduleSpinTick(finalIndex, totalTicks);
+		scheduleSpinTick(totalTicks);
 	}
 
 	function clearPick() {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -465,10 +465,10 @@
 				{/if}
 				{#each displayedGames as game, i (`${game.id}-${i}`)}
 					{@const g = game as BggGame}
-					<div class="game-card-wrap" class:game-card-wrap--popover={data.stats === 1 && g.stats}>
-						{#if data.stats === 1 && g.stats}
-							<div class="game-popover font-oswald" role="tooltip">
-								<p class="game-popover-title">{g.name ?? 'Game'}</p>
+					<div class="game-card-wrap">
+						<div class="game-popover font-oswald" role="tooltip">
+							<p class="game-popover-title">{g.name ?? 'Game'}</p>
+							{#if data.stats === 1 && g.stats}
 								<dl class="game-popover-dl">
 									<dt>Your plays</dt>
 									<dd>{g.numplays ?? '—'}</dd>
@@ -492,8 +492,12 @@
 										{/if}
 									</dd>
 								</dl>
-							</div>
-						{/if}
+							{:else}
+								<p class="game-popover-note">
+									Open full details for players, play time, and ratings.
+								</p>
+							{/if}
+						</div>
 						<a
 							href="https://boardgamegeek.com/boardgame/{g.id}"
 							target="_blank"
@@ -1026,58 +1030,122 @@
 	}
 
 	.games-flex {
-		margin-block-start: 1.5rem;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0;
+		position: relative;
+		isolation: isolate;
+		margin-block-start: 1.75rem;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+		gap: 1.45rem 1rem;
 		max-width: 1400px;
-		align-items: flex-end;
-		border-left: 15px solid #a0522d;
-		border-right: 15px solid #a0522d;
+		margin-inline: auto;
+		padding: clamp(1rem, 2vw, 1.5rem);
+		border: 10px solid #6f351c;
+		border-image: linear-gradient(90deg, #4f2414, #a75b2a, #5f2c18) 1;
+		background:
+			linear-gradient(90deg, rgb(57 26 12 / 0.24), transparent 12%, transparent 88%, rgb(57 26 12 / 0.24)),
+			repeating-linear-gradient(
+				90deg,
+				rgb(255 255 255 / 0.05) 0 2px,
+				transparent 2px 28px
+			),
+			linear-gradient(180deg, #8a4c27 0%, #5f2f19 100%);
+		box-shadow:
+			inset 0 0 0 3px rgb(255 255 255 / 0.08),
+			0 10px 0 #3d1d10,
+			0 16px 24px rgb(0 0 0 / 0.22);
+	}
+
+	.games-flex::before,
+	.games-flex::after {
+		content: '';
+		position: absolute;
+		z-index: -1;
+		left: 0.65rem;
+		right: 0.65rem;
+		height: 0.75rem;
+		border-radius: 999px;
+		background: rgb(49 22 10 / 0.32);
+		filter: blur(5px);
+		pointer-events: none;
+	}
+
+	.games-flex::before {
+		top: 0.45rem;
+	}
+
+	.games-flex::after {
+		bottom: 0.45rem;
 	}
 
 	.game-card-wrap {
 		position: relative;
+		isolation: isolate;
+		align-self: end;
+		justify-self: center;
+		padding: 0 0.35rem 0.65rem;
 	}
 
-	/* Bridge hover gap so the pointer can reach the tooltip without flicker */
-	.game-card-wrap--popover::before {
+	.game-card-wrap::after {
 		content: '';
 		position: absolute;
+		z-index: 0;
 		left: 0;
 		right: 0;
-		bottom: 100%;
-		height: 0.85rem;
-		z-index: 19;
+		bottom: 0;
+		height: 0.9rem;
+		border-radius: 0.15rem;
+		background:
+			linear-gradient(180deg, #b66a34, #6e351b 70%, #3f1d0f),
+			repeating-linear-gradient(90deg, rgb(255 255 255 / 0.12) 0 2px, transparent 2px 22px);
+		box-shadow:
+			0 0.35rem 0 #3a1b0d,
+			0 0.7rem 1rem rgb(0 0 0 / 0.28);
 	}
 
-	.game-card-wrap--popover:hover .game-popover,
-	.game-card-wrap--popover:focus-within .game-popover {
+	.game-card-wrap::before {
+		content: '';
+		position: absolute;
+		z-index: 0;
+		left: 0.35rem;
+		right: 0.35rem;
+		bottom: 1.05rem;
+		height: 0.55rem;
+		background: linear-gradient(180deg, rgb(0 0 0 / 0.2), transparent);
+		pointer-events: none;
+	}
+
+	.game-card-wrap:hover .game-popover,
+	.game-card-wrap:focus-within .game-popover {
 		opacity: 1;
 		visibility: visible;
 		pointer-events: auto;
+		transform: translate(-50%, -0.35rem);
 	}
 
 	.game-popover {
 		position: absolute;
 		z-index: 20;
 		left: 50%;
-		bottom: calc(100% + 0.35rem);
-		transform: translateX(-50%);
-		min-width: 11.5rem;
-		max-width: 16rem;
-		padding: 0.65rem 0.75rem;
-		font-size: 0.72rem;
+		bottom: calc(100% + 0.55rem);
+		transform: translate(-50%, 0);
+		width: min(15.5rem, 78vw);
+		padding: 0.8rem 0.9rem;
+		font-size: 0.74rem;
 		line-height: 1.35;
 		color: var(--color-white-lightest);
-		background: var(--color-tertiary-darkest);
-		border: 1px solid var(--color-primary);
-		box-shadow: 4px 4px 0 var(--color-primary-darker);
+		background:
+			linear-gradient(135deg, rgb(255 255 255 / 0.06), transparent),
+			var(--color-tertiary-darkest);
+		border: 2px solid var(--color-primary);
+		box-shadow:
+			5px 5px 0 var(--color-primary-darker),
+			0 10px 22px rgb(0 0 0 / 0.28);
 		opacity: 0;
 		visibility: hidden;
 		pointer-events: none;
 		transition:
 			opacity 0.15s ease,
+			transform 0.15s ease,
 			visibility 0.15s ease;
 	}
 
@@ -1085,26 +1153,30 @@
 		content: '';
 		position: absolute;
 		left: 50%;
-		bottom: -6px;
-		transform: translateX(-50%);
-		border: 6px solid transparent;
-		border-top-color: var(--color-primary);
+		bottom: -8px;
+		transform: translateX(-50%) rotate(45deg);
+		width: 0.85rem;
+		height: 0.85rem;
+		background: var(--color-tertiary-darkest);
+		border-right: 2px solid var(--color-primary);
+		border-bottom: 2px solid var(--color-primary);
 	}
 
 	.game-popover-title {
-		margin: 0 0 0.4rem;
+		margin: 0 0 0.5rem;
 		font-family: var(--font-special-elite);
-		font-size: 0.8rem;
+		font-size: 0.9rem;
+		line-height: 1.2;
 		color: var(--color-white-lightest);
-		border-bottom: 1px solid var(--color-tertiary);
-		padding-bottom: 0.35rem;
+		border-bottom: 1px solid rgb(255 255 255 / 0.24);
+		padding-bottom: 0.45rem;
 	}
 
 	.game-popover-dl {
 		margin: 0;
 		display: grid;
 		grid-template-columns: auto 1fr;
-		gap: 0.15rem 0.65rem;
+		gap: 0.22rem 0.75rem;
 		align-items: baseline;
 	}
 
@@ -1112,6 +1184,8 @@
 		margin: 0;
 		color: var(--color-tertiary-lighter);
 		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
 	}
 
 	.game-popover-dl dd {
@@ -1126,22 +1200,38 @@
 		margin-top: 0.1rem;
 	}
 
+	.game-popover-note {
+		margin: 0;
+		color: var(--color-tertiary-lighter);
+	}
+
 	.game-card {
+		position: relative;
+		z-index: 1;
 		display: block;
-		width: 150px;
+		width: clamp(96px, 12vw, 145px);
 		flex-shrink: 0;
 		text-decoration: none;
 		transition:
 			transform 0.2s ease,
-			box-shadow 0.2s ease;
+			box-shadow 0.2s ease,
+			filter 0.2s ease;
 		overflow: hidden;
-		border-bottom: 15px solid #a0522d;
-		margin-bottom: 1.5rem;
+		border: 3px solid #efe1c7;
+		background: var(--color-white-lightest);
+		box-shadow:
+			0 0.25rem 0 rgb(55 24 11 / 0.38),
+			0 0.7rem 0.85rem rgb(0 0 0 / 0.22);
+		transform-origin: bottom center;
 	}
 
-	.game-card:hover {
-		transform: translateY(-4px);
-		box-shadow: 8px 8px 0 var(--color-primary);
+	.game-card:hover,
+	.game-card:focus-visible {
+		transform: translateY(-8px) rotate(-1deg);
+		box-shadow:
+			0 0 0 3px var(--color-primary),
+			0 0.85rem 1rem rgb(0 0 0 / 0.3);
+		filter: saturate(1.05);
 	}
 
 	.game-image {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -35,7 +35,7 @@
 	let spinTick = $state(0);
 	let spinTimeout: ReturnType<typeof setTimeout> | null = null;
 
-	const SPIN_VISIBLE_RADIUS = 4;
+	const SPIN_VISIBLE_RADIUS = 2;
 	const SPIN_MIN_TICKS = 28;
 	const SPIN_EXTRA_TICKS = 18;
 
@@ -697,44 +697,33 @@
 		padding: 1.5rem clamp(0.75rem, 2vw, 1.5rem) 1.75rem;
 		text-align: center;
 		border: 3px solid var(--color-primary-darker);
-		background:
-			linear-gradient(135deg, rgb(255 255 255 / 0.86), rgb(255 255 255 / 0.68)),
-			repeating-linear-gradient(
-				45deg,
-				var(--color-tertiary-darkest) 0 0.75rem,
-				var(--color-primary-darker) 0.75rem 1.5rem
-			);
+		background: var(--color-white-lightest);
 		box-shadow: 8px 8px 0 var(--color-primary);
 		overflow: hidden;
+		--wheel-slot-gap: clamp(0.35rem, 1.5vw, 0.75rem);
+		--wheel-slot-width: clamp(5.5rem, 16vw, 8rem);
 	}
 
 	.wheel-window {
 		position: relative;
 		margin-inline: auto;
 		padding-block: 1.5rem 1rem;
+		width: fit-content;
 		max-width: 100%;
 		overflow: hidden;
 	}
 
-	.wheel-window::before,
-	.wheel-window::after {
+	.wheel-window::before {
 		content: '';
 		position: absolute;
 		z-index: 2;
 		top: 0;
 		bottom: 0;
-		width: clamp(1.5rem, 8vw, 6rem);
+		left: 50%;
+		width: 2px;
+		transform: translateX(-50%);
+		background: rgb(0 0 0 / 0.12);
 		pointer-events: none;
-	}
-
-	.wheel-window::before {
-		left: 0;
-		background: linear-gradient(90deg, var(--color-white-lightest), transparent);
-	}
-
-	.wheel-window::after {
-		right: 0;
-		background: linear-gradient(270deg, var(--color-white-lightest), transparent);
 	}
 
 	.wheel-pointer {
@@ -765,12 +754,14 @@
 		display: flex;
 		justify-content: center;
 		align-items: stretch;
-		gap: clamp(0.35rem, 1.5vw, 0.75rem);
-		min-width: max-content;
+		gap: var(--wheel-slot-gap);
+		width: calc((var(--wheel-slot-width) * 5) + (var(--wheel-slot-gap) * 4));
+		max-width: 100%;
 	}
 
 	.wheel-slot {
-		width: clamp(5.5rem, 16vw, 8rem);
+		width: var(--wheel-slot-width);
+		flex: 0 0 var(--wheel-slot-width);
 		padding: 0.55rem;
 		border: 2px solid var(--color-tertiary-lighter);
 		background: var(--color-white-lightest);

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -24,7 +24,6 @@
 	const { data } = $props();
 
 	let lookupUsername = $state('');
-	let statsLevel = $state<'0' | '1'>('0');
 	let playFilter = $state<'all' | 'played' | 'unplayed'>('all');
 	let playerCountFilter = $state<'all' | '1' | '2' | '3' | '4' | '5' | '6'>('all');
 	let playtimeFilter = $state<'all' | '30' | '60' | '90' | '120' | '150' | '180'>('all');
@@ -41,13 +40,11 @@
 
 	$effect(() => {
 		lookupUsername = data.username;
-		statsLevel = data.stats === 1 ? '1' : '0';
 	});
 
 	/** Reset filters when the loaded collection changes (new fetch / navigation). */
 	$effect(() => {
 		void data.username;
-		void data.stats;
 		void data.total;
 		playFilter = 'all';
 		playerCountFilter = 'all';
@@ -93,7 +90,6 @@
 
 	const displayedGames = $derived.by(() => {
 		const games = data.games as BggGame[];
-		if (data.stats !== 1) return games;
 
 		let list = games;
 
@@ -245,7 +241,11 @@
 	function handleLookup() {
 		const trimmed = lookupUsername.trim();
 		if (!trimmed) return;
-		goto(`/board-games?username=${encodeURIComponent(trimmed)}&stats=${statsLevel}`);
+		goto(`/board-games?username=${encodeURIComponent(trimmed)}`);
+	}
+
+	function getBgStatsAddPlayHref(game: BggGame): string {
+		return `https://app.bgstatsapp.com/addPlay.html?gameId=${encodeURIComponent(String(game.id))}`;
 	}
 </script>
 
@@ -275,11 +275,6 @@
 					placeholder="BGG username..."
 					bind:value={lookupUsername}
 				/>
-				<label class="stats-label font-oswald" for="bgg-stats-level">Detail</label>
-				<select id="bgg-stats-level" class="stats-select font-oswald" bind:value={statsLevel}>
-					<option value="0">Basic</option>
-					<option value="1">Full</option>
-				</select>
 				<button class="lookup-btn font-oswald" type="submit">Fetch</button>
 			</form>
 		</header>
@@ -294,7 +289,7 @@
 			</div>
 		{/if}
 
-		{#if data.stats === 1 && !data.error && data.games.length > 0}
+		{#if !data.error && data.games.length > 0}
 			<div class="filters-bar font-oswald">
 				<div class="filter-group">
 					<label class="filter-label" for="bgg-play-filter">Play status</label>
@@ -404,44 +399,46 @@
 						<div class="picked-meta">
 							<p class="result-eyebrow font-oswald">Tonight's game</p>
 							<h2 class="picked-title font-special-elite">{g.name ?? 'Game'}</h2>
-							{#if data.stats === 1 && g.stats}
-								<dl class="picked-dl font-oswald">
-									<div class="picked-dl-row">
-										<dt>Your plays</dt>
-										<dd>{g.numplays ?? '—'}</dd>
-									</div>
-									<div class="picked-dl-row">
-										<dt>Players</dt>
-										<dd>
-											{#if g.stats.minplayers != null && g.stats.maxplayers != null}
-												{g.stats.minplayers}–{g.stats.maxplayers}
-											{:else}
-												—
-											{/if}
-										</dd>
-									</div>
-									<div class="picked-dl-row">
-										<dt>Play time</dt>
-										<dd>{formatPlayTime(g)}</dd>
-									</div>
-									<div class="picked-dl-row">
-										<dt>Avg rating</dt>
-										<dd>
-											{formatAvg(g.stats.rating?.average)}
-											{#if g.stats.rating?.usersrated != null}
-												<span class="picked-dl-sub">
-													({g.stats.rating.usersrated.toLocaleString()} votes)
-												</span>
-											{/if}
-										</dd>
-									</div>
-								</dl>
-							{:else}
-								<p class="result-note font-oswald">
-									Fetch full details to see player count, play time, and ratings here.
-								</p>
-							{/if}
+							<dl class="picked-dl font-oswald">
+								<div class="picked-dl-row">
+									<dt>Your plays</dt>
+									<dd>{g.numplays ?? '—'}</dd>
+								</div>
+								<div class="picked-dl-row">
+									<dt>Players</dt>
+									<dd>
+										{#if g.stats?.minplayers != null && g.stats.maxplayers != null}
+											{g.stats.minplayers}–{g.stats.maxplayers}
+										{:else}
+											—
+										{/if}
+									</dd>
+								</div>
+								<div class="picked-dl-row">
+									<dt>Play time</dt>
+									<dd>{formatPlayTime(g)}</dd>
+								</div>
+								<div class="picked-dl-row">
+									<dt>Avg rating</dt>
+									<dd>
+										{formatAvg(g.stats?.rating?.average)}
+										{#if g.stats?.rating?.usersrated != null}
+											<span class="picked-dl-sub">
+												({g.stats.rating.usersrated.toLocaleString()} votes)
+											</span>
+										{/if}
+									</dd>
+								</div>
+							</dl>
 							<div class="picked-actions">
+								<a
+									class="picked-bgstats-link lookup-btn font-oswald"
+									href={getBgStatsAddPlayHref(g)}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Open in BG Stats
+								</a>
 								<a
 									class="picked-bgg-link lookup-btn font-oswald"
 									href="https://boardgamegeek.com/boardgame/{g.id}"
@@ -468,35 +465,29 @@
 					<div class="game-card-wrap">
 						<div class="game-popover font-oswald" role="tooltip">
 							<p class="game-popover-title">{g.name ?? 'Game'}</p>
-							{#if data.stats === 1 && g.stats}
-								<dl class="game-popover-dl">
-									<dt>Your plays</dt>
-									<dd>{g.numplays ?? '—'}</dd>
-									<dt>Players</dt>
-									<dd>
-										{#if g.stats.minplayers != null && g.stats.maxplayers != null}
-											{g.stats.minplayers}–{g.stats.maxplayers}
-										{:else}
-											—
-										{/if}
-									</dd>
-									<dt>Play time</dt>
-									<dd>{formatPlayTime(g)}</dd>
-									<dt>Avg rating</dt>
-									<dd>
-										{formatAvg(g.stats.rating?.average)}
-										{#if g.stats.rating?.usersrated != null}
-											<span class="game-popover-sub">
-												({g.stats.rating.usersrated.toLocaleString()} votes)
-											</span>
-										{/if}
-									</dd>
-								</dl>
-							{:else}
-								<p class="game-popover-note">
-									Open full details for players, play time, and ratings.
-								</p>
-							{/if}
+							<dl class="game-popover-dl">
+								<dt>Your plays</dt>
+								<dd>{g.numplays ?? '—'}</dd>
+								<dt>Players</dt>
+								<dd>
+									{#if g.stats?.minplayers != null && g.stats.maxplayers != null}
+										{g.stats.minplayers}–{g.stats.maxplayers}
+									{:else}
+										—
+									{/if}
+								</dd>
+								<dt>Play time</dt>
+								<dd>{formatPlayTime(g)}</dd>
+								<dt>Avg rating</dt>
+								<dd>
+									{formatAvg(g.stats?.rating?.average)}
+									{#if g.stats?.rating?.usersrated != null}
+										<span class="game-popover-sub">
+											({g.stats.rating.usersrated.toLocaleString()} votes)
+										</span>
+									{/if}
+								</dd>
+							</dl>
 						</div>
 						<a
 							href="https://boardgamegeek.com/boardgame/{g.id}"
@@ -578,22 +569,6 @@
 
 	.lookup-input::placeholder {
 		color: var(--color-tertiary-lighter);
-	}
-
-	.stats-label {
-		font-size: 0.8rem;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--color-tertiary);
-	}
-
-	.stats-select {
-		padding: 0.45rem 0.5rem;
-		font-size: 0.85rem;
-		border: 1px solid var(--color-tertiary-lighter);
-		background: var(--color-white-lightest);
-		color: var(--color-tertiary-darkest);
-		cursor: pointer;
 	}
 
 	.lookup-btn {
@@ -942,15 +917,6 @@
 		color: var(--color-primary);
 	}
 
-	.result-note {
-		margin: 1rem auto 1.25rem;
-		max-width: 24rem;
-		padding: 0.8rem 1rem;
-		color: var(--color-tertiary-darker);
-		background: rgb(255 255 255 / 0.72);
-		border: 1px solid var(--color-tertiary-lighter);
-	}
-
 	.picked-dl {
 		margin: 1rem 0 1.25rem;
 		display: grid;
@@ -1006,6 +972,18 @@
 	.picked-bgg-link {
 		text-decoration: none;
 		display: inline-block;
+	}
+
+	.picked-bgstats-link {
+		text-decoration: none;
+		display: inline-block;
+		background: var(--color-tertiary-darkest);
+		border-color: var(--color-tertiary-darkest);
+	}
+
+	.picked-bgstats-link:hover {
+		background: var(--color-primary-darker);
+		border-color: var(--color-primary-darker);
 	}
 
 	.picked-back {
@@ -1169,11 +1147,6 @@
 		font-size: 0.65rem;
 		color: var(--color-tertiary-lighter);
 		margin-top: 0.1rem;
-	}
-
-	.game-popover-note {
-		margin: 0;
-		color: var(--color-tertiary-lighter);
 	}
 
 	.game-card {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -262,21 +262,6 @@
 					{data.total === 1 ? 'game' : 'games'} in collection
 				</p>
 			{/if}
-			<form
-				class="lookup"
-				onsubmit={(e) => {
-					e.preventDefault();
-					handleLookup();
-				}}
-			>
-				<input
-					class="lookup-input font-special-elite"
-					type="text"
-					placeholder="BGG username..."
-					bind:value={lookupUsername}
-				/>
-				<button class="lookup-btn font-oswald" type="submit">Fetch</button>
-			</form>
 		</header>
 
 		{#if data.error}
@@ -289,8 +274,28 @@
 			</div>
 		{/if}
 
-		{#if !data.error && data.games.length > 0}
-			<div class="filters-bar font-oswald">
+		<form
+			class="controls-panel font-oswald"
+			onsubmit={(e) => {
+				e.preventDefault();
+				handleLookup();
+			}}
+		>
+			<div class="filter-group username-filter-group">
+				<label class="filter-label" for="bgg-username">BGG username</label>
+				<div class="lookup-inline">
+					<input
+						id="bgg-username"
+						class="lookup-input font-special-elite"
+						type="text"
+						placeholder="BGG username..."
+						bind:value={lookupUsername}
+					/>
+					<button class="lookup-btn font-oswald" type="submit">Fetch</button>
+				</div>
+			</div>
+
+			{#if !data.error && data.games.length > 0}
 				<div class="filter-group">
 					<label class="filter-label" for="bgg-play-filter">Play status</label>
 					<select id="bgg-play-filter" class="filter-select" bind:value={playFilter}>
@@ -327,32 +332,27 @@
 					{displayedGames.length}
 					{displayedGames.length === 1 ? 'game' : 'games'} displaying
 				</span>
-			</div>
-		{/if}
-
-		{#if !data.error && data.games.length > 0}
-			<div class="pick-row">
-				<button
-					type="button"
-					class="pick-btn font-oswald"
-					disabled={displayedGames.length === 0 || isSpinning}
-					onclick={pickRandomGame}
-				>
-					{#if isSpinning}
-						Spinning...
-					{:else if pickedGame}
-						Spin again
-					{:else}
-						Find me a game
+				<div class="controls-actions">
+					{#if pickedGame && !isSpinning}
+						<button type="button" class="collection-btn font-oswald" onclick={clearPick}>
+							View full collection
+						</button>
 					{/if}
-				</button>
-				{#if pickedGame && !isSpinning}
-					<button type="button" class="collection-btn font-oswald" onclick={clearPick}>
-						View full collection
+					<button
+						type="button"
+						class="pick-btn font-oswald"
+						disabled={displayedGames.length === 0 || isSpinning}
+						onclick={pickRandomGame}
+					>
+						{#if isSpinning}
+							Spinning...
+						{:else}
+							Pick a game for me
+						{/if}
 					</button>
-				{/if}
-			</div>
-		{/if}
+				</div>
+			{/if}
+		</form>
 
 		{#if isSpinning || pickedGame}
 			<section
@@ -447,9 +447,6 @@
 								>
 									Open on BoardGameGeek
 								</a>
-								<button type="button" class="picked-back font-oswald" onclick={clearPick}>
-									View full collection
-								</button>
 							</div>
 						</div>
 					</div>
@@ -547,14 +544,27 @@
 		margin: 0 0 1.25rem;
 	}
 
-	.lookup {
+	.controls-panel {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
-		align-items: center;
-		gap: 0.5rem;
-		max-width: 32rem;
+		align-items: flex-end;
+		gap: 0.75rem 1rem;
+		max-width: 68rem;
 		margin-inline: auto;
+		padding: 0.85rem 1rem;
+		border: 1px solid var(--color-tertiary-lighter);
+		background: var(--color-white-lightest);
+	}
+
+	.username-filter-group {
+		flex: 1 1 16rem;
+	}
+
+	.lookup-inline {
+		display: flex;
+		width: 100%;
+		gap: 0.5rem;
 	}
 
 	.lookup-input {
@@ -594,20 +604,6 @@
 		font-family: var(--font-oswald);
 		font-size: var(--fs-base);
 		color: var(--color-tertiary);
-	}
-
-	.filters-bar {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		align-items: flex-end;
-		gap: 0.5rem 1rem;
-		margin-block-start: 1rem;
-		padding: 0.75rem 1rem;
-		max-width: 52rem;
-		margin-inline: auto;
-		border: 1px solid var(--color-tertiary-lighter);
-		background: var(--color-white-lightest);
 	}
 
 	.filter-group {
@@ -659,7 +655,7 @@
 		color: var(--color-tertiary);
 	}
 
-	.pick-row {
+	.controls-actions {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
@@ -984,27 +980,6 @@
 	.picked-bgstats-link:hover {
 		background: var(--color-primary-darker);
 		border-color: var(--color-primary-darker);
-	}
-
-	.picked-back {
-		padding: 0.5rem 1rem;
-		font-size: 0.85rem;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		background: var(--color-white-lightest);
-		color: var(--color-tertiary-darker);
-		border: 2px solid var(--color-tertiary-lighter);
-		cursor: pointer;
-		transition:
-			background 0.2s,
-			border-color 0.2s,
-			transform 0.15s ease;
-	}
-
-	.picked-back:hover {
-		background: var(--color-white-lightest);
-		border-color: var(--color-tertiary);
-		transform: translateY(-2px);
 	}
 
 	.games-flex {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1034,84 +1034,41 @@
 		isolation: isolate;
 		margin-block-start: 1.75rem;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
-		gap: 1.45rem 1rem;
+		grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+		grid-auto-rows: var(--shelf-row-height);
+		align-items: end;
+		gap: 0.75rem 0.85rem;
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: clamp(1rem, 2vw, 1.5rem);
-		border: 10px solid #6f351c;
-		border-image: linear-gradient(90deg, #4f2414, #a75b2a, #5f2c18) 1;
+		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.5rem;
+		border: 7px solid #5f2f19;
 		background:
-			linear-gradient(90deg, rgb(57 26 12 / 0.24), transparent 12%, transparent 88%, rgb(57 26 12 / 0.24)),
+			linear-gradient(90deg, rgb(52 23 10 / 0.3), transparent 8%, transparent 92%, rgb(52 23 10 / 0.3)),
+			repeating-linear-gradient(90deg, rgb(255 255 255 / 0.08) 0 1px, transparent 1px 34px),
 			repeating-linear-gradient(
-				90deg,
-				rgb(255 255 255 / 0.05) 0 2px,
-				transparent 2px 28px
+				to bottom,
+				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
+				#b86a34 calc(var(--shelf-row-height) - var(--shelf-board-height))
+					calc(var(--shelf-row-height) - 0.46rem),
+				#7a3d20 calc(var(--shelf-row-height) - 0.46rem)
+					calc(var(--shelf-row-height) - 0.1rem),
+				#3d1d10 calc(var(--shelf-row-height) - 0.1rem) var(--shelf-row-height)
 			),
-			linear-gradient(180deg, #8a4c27 0%, #5f2f19 100%);
+			linear-gradient(180deg, #a85e2f 0%, #81411f 100%);
 		box-shadow:
-			inset 0 0 0 3px rgb(255 255 255 / 0.08),
-			0 10px 0 #3d1d10,
-			0 16px 24px rgb(0 0 0 / 0.22);
-	}
-
-	.games-flex::before,
-	.games-flex::after {
-		content: '';
-		position: absolute;
-		z-index: -1;
-		left: 0.65rem;
-		right: 0.65rem;
-		height: 0.75rem;
-		border-radius: 999px;
-		background: rgb(49 22 10 / 0.32);
-		filter: blur(5px);
-		pointer-events: none;
-	}
-
-	.games-flex::before {
-		top: 0.45rem;
-	}
-
-	.games-flex::after {
-		bottom: 0.45rem;
+			inset 0 0 0 2px rgb(255 255 255 / 0.1),
+			inset 0 0 2rem rgb(50 22 9 / 0.22),
+			0 0.7rem 0 #3d1d10,
+			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
+		--shelf-row-height: clamp(12.5rem, 19vw, 14.75rem);
+		--shelf-board-height: 1.45rem;
 	}
 
 	.game-card-wrap {
 		position: relative;
-		isolation: isolate;
 		align-self: end;
 		justify-self: center;
-		padding: 0 0.35rem 0.65rem;
-	}
-
-	.game-card-wrap::after {
-		content: '';
-		position: absolute;
-		z-index: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		height: 0.9rem;
-		border-radius: 0.15rem;
-		background:
-			linear-gradient(180deg, #b66a34, #6e351b 70%, #3f1d0f),
-			repeating-linear-gradient(90deg, rgb(255 255 255 / 0.12) 0 2px, transparent 2px 22px);
-		box-shadow:
-			0 0.35rem 0 #3a1b0d,
-			0 0.7rem 1rem rgb(0 0 0 / 0.28);
-	}
-
-	.game-card-wrap::before {
-		content: '';
-		position: absolute;
-		z-index: 0;
-		left: 0.35rem;
-		right: 0.35rem;
-		bottom: 1.05rem;
-		height: 0.55rem;
-		background: linear-gradient(180deg, rgb(0 0 0 / 0.2), transparent);
-		pointer-events: none;
+		padding-bottom: calc(var(--shelf-board-height) - 0.2rem);
 	}
 
 	.game-card-wrap:hover .game-popover,

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -29,6 +29,15 @@
 	let playerCountFilter = $state<'all' | '1' | '2' | '3' | '4' | '5' | '6'>('all');
 	let playtimeFilter = $state<'all' | '30' | '60' | '90' | '120' | '150' | '180'>('all');
 	let pickedGame = $state<BggGame | null>(null);
+	let isSpinning = $state(false);
+	let spinGames = $state<BggGame[]>([]);
+	let highlightedSpinIndex = $state(0);
+	let spinTick = $state(0);
+	let spinTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	const SPIN_VISIBLE_RADIUS = 4;
+	const SPIN_MIN_TICKS = 28;
+	const SPIN_EXTRA_TICKS = 18;
 
 	$effect(() => {
 		lookupUsername = data.username;
@@ -43,6 +52,9 @@
 		playFilter = 'all';
 		playerCountFilter = 'all';
 		playtimeFilter = 'all';
+		clearSpinTimer();
+		isSpinning = false;
+		spinGames = [];
 		pickedGame = null;
 	});
 
@@ -111,15 +123,99 @@
 		if (pickedGame && !list.some((g) => g.id === pickedGame!.id)) {
 			pickedGame = null;
 		}
+		if (isSpinning && spinGames.some((spinGame) => !list.some((g) => g.id === spinGame.id))) {
+			clearSpinTimer();
+			isSpinning = false;
+			spinGames = [];
+			pickedGame = null;
+		}
 	});
+
+	$effect(() => {
+		return () => {
+			clearSpinTimer();
+		};
+	});
+
+	function clearSpinTimer() {
+		if (spinTimeout) {
+			clearTimeout(spinTimeout);
+			spinTimeout = null;
+		}
+	}
+
+	function positiveModulo(value: number, length: number): number {
+		return ((value % length) + length) % length;
+	}
+
+	function shuffleGames(games: BggGame[]): BggGame[] {
+		const shuffled = [...games];
+		for (let i = shuffled.length - 1; i > 0; i -= 1) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+		}
+		return shuffled;
+	}
+
+	function getSpinSlots() {
+		if (spinGames.length === 0) return [];
+
+		return Array.from({ length: SPIN_VISIBLE_RADIUS * 2 + 1 }, (_, index) => {
+			const offset = index - SPIN_VISIBLE_RADIUS;
+			const gameIndex = positiveModulo(highlightedSpinIndex + offset, spinGames.length);
+			const game = spinGames[gameIndex];
+
+			return {
+				game,
+				offset,
+				isCenter: offset === 0,
+				key: `${game.id}-${offset}`
+			};
+		});
+	}
+
+	function scheduleSpinTick(finalIndex: number, totalTicks: number) {
+		const progress = spinTick / totalTicks;
+		const delay = 55 + Math.pow(progress, 3) * 190;
+
+		spinTimeout = setTimeout(() => {
+			if (spinGames.length === 0) return;
+
+			spinTick += 1;
+			highlightedSpinIndex = (highlightedSpinIndex + 1) % spinGames.length;
+
+			if (spinTick >= totalTicks) {
+				clearSpinTimer();
+				isSpinning = false;
+				pickedGame = spinGames[finalIndex] ?? spinGames[highlightedSpinIndex] ?? null;
+				return;
+			}
+
+			scheduleSpinTick(finalIndex, totalTicks);
+		}, delay);
+	}
 
 	function pickRandomGame() {
 		const list = displayedGames;
 		if (list.length === 0) return;
-		pickedGame = list[Math.floor(Math.random() * list.length)] as BggGame;
+
+		clearSpinTimer();
+		const wheelGames = shuffleGames(list);
+		const finalIndex = Math.floor(Math.random() * wheelGames.length);
+		const totalTicks = SPIN_MIN_TICKS + Math.floor(Math.random() * SPIN_EXTRA_TICKS);
+
+		spinGames = wheelGames;
+		highlightedSpinIndex = positiveModulo(finalIndex - (totalTicks % wheelGames.length), wheelGames.length);
+		spinTick = 0;
+		pickedGame = null;
+		isSpinning = true;
+		scheduleSpinTick(finalIndex, totalTicks);
 	}
 
 	function clearPick() {
+		clearSpinTimer();
+		isSpinning = false;
+		spinGames = [];
 		pickedGame = null;
 	}
 
@@ -240,15 +336,45 @@
 				<button
 					type="button"
 					class="pick-btn font-oswald"
-					disabled={displayedGames.length === 0}
+					disabled={displayedGames.length === 0 || isSpinning}
 					onclick={pickRandomGame}
 				>
-					Pick a game for me
+					{isSpinning ? 'Spinning...' : 'Find me a game'}
 				</button>
 			</div>
 		{/if}
 
-		{#if pickedGame}
+		{#if isSpinning}
+			<section class="pick-wheel" aria-live="polite" aria-busy="true">
+				<p class="picked-kicker font-oswald">Game roulette</p>
+				<p class="picked-tagline font-special-elite">
+					Spinning {displayedGames.length}
+					{displayedGames.length === 1 ? 'eligible game' : 'eligible games'}...
+				</p>
+				<div class="wheel-window">
+					<div class="wheel-pointer" aria-hidden="true"></div>
+					<div class="wheel-strip">
+						{#each getSpinSlots() as slot (slot.key)}
+							<div class="wheel-slot" class:wheel-slot--active={slot.isCenter}>
+								<div class="wheel-image-frame">
+									{#if slot.game.thumbnail || slot.game.image}
+										<img
+											class="wheel-image"
+											src={slot.game.thumbnail ?? slot.game.image}
+											alt={slot.game.name ?? 'Game cover'}
+											loading="lazy"
+										/>
+									{:else}
+										<div class="wheel-image-placeholder font-oswald">No image</div>
+									{/if}
+								</div>
+								<p class="wheel-title font-oswald">{slot.game.name ?? 'Mystery game'}</p>
+							</div>
+						{/each}
+					</div>
+				</div>
+			</section>
+		{:else if pickedGame}
 			{@const g = pickedGame}
 			<section class="picked-hero" aria-live="polite">
 				<p class="picked-kicker font-oswald">Your pick</p>
@@ -562,6 +688,154 @@
 	.pick-btn:disabled {
 		opacity: 0.45;
 		cursor: not-allowed;
+	}
+
+	.pick-wheel {
+		margin-block-start: 1.75rem;
+		max-width: 58rem;
+		margin-inline: auto;
+		padding: 1.5rem clamp(0.75rem, 2vw, 1.5rem) 1.75rem;
+		text-align: center;
+		border: 3px solid var(--color-primary-darker);
+		background:
+			linear-gradient(135deg, rgb(255 255 255 / 0.86), rgb(255 255 255 / 0.68)),
+			repeating-linear-gradient(
+				45deg,
+				var(--color-tertiary-darkest) 0 0.75rem,
+				var(--color-primary-darker) 0.75rem 1.5rem
+			);
+		box-shadow: 8px 8px 0 var(--color-primary);
+		overflow: hidden;
+	}
+
+	.wheel-window {
+		position: relative;
+		margin-inline: auto;
+		padding-block: 1.5rem 1rem;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	.wheel-window::before,
+	.wheel-window::after {
+		content: '';
+		position: absolute;
+		z-index: 2;
+		top: 0;
+		bottom: 0;
+		width: clamp(1.5rem, 8vw, 6rem);
+		pointer-events: none;
+	}
+
+	.wheel-window::before {
+		left: 0;
+		background: linear-gradient(90deg, var(--color-white-lightest), transparent);
+	}
+
+	.wheel-window::after {
+		right: 0;
+		background: linear-gradient(270deg, var(--color-white-lightest), transparent);
+	}
+
+	.wheel-pointer {
+		position: absolute;
+		z-index: 4;
+		top: 0.15rem;
+		left: 50%;
+		width: 0;
+		height: 0;
+		transform: translateX(-50%);
+		border-inline: 0.75rem solid transparent;
+		border-top: 1rem solid var(--color-primary);
+		filter: drop-shadow(0 2px 0 var(--color-tertiary-darkest));
+	}
+
+	.wheel-pointer::after {
+		content: '';
+		position: absolute;
+		top: -1.35rem;
+		left: -0.35rem;
+		width: 0.7rem;
+		height: 0.7rem;
+		border-radius: 50%;
+		background: var(--color-tertiary-darkest);
+	}
+
+	.wheel-strip {
+		display: flex;
+		justify-content: center;
+		align-items: stretch;
+		gap: clamp(0.35rem, 1.5vw, 0.75rem);
+		min-width: max-content;
+	}
+
+	.wheel-slot {
+		width: clamp(5.5rem, 16vw, 8rem);
+		padding: 0.55rem;
+		border: 2px solid var(--color-tertiary-lighter);
+		background: var(--color-white-lightest);
+		box-shadow: 4px 4px 0 rgb(0 0 0 / 0.16);
+		opacity: 0.54;
+		transform: scale(0.86) rotate(var(--slot-tilt, 0deg));
+		transition:
+			opacity 0.12s ease,
+			transform 0.12s ease,
+			border-color 0.12s ease;
+	}
+
+	.wheel-slot:nth-child(odd) {
+		--slot-tilt: -2deg;
+	}
+
+	.wheel-slot:nth-child(even) {
+		--slot-tilt: 2deg;
+	}
+
+	.wheel-slot--active {
+		position: relative;
+		z-index: 3;
+		border-color: var(--color-primary);
+		opacity: 1;
+		transform: scale(1.08) rotate(0deg);
+		box-shadow: 0 0 0 4px var(--color-primary-darker), 8px 8px 0 rgb(0 0 0 / 0.2);
+	}
+
+	.wheel-image-frame {
+		aspect-ratio: 1 / 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		background: var(--color-white-lightest);
+		border-bottom: 0.55rem solid #a0522d;
+	}
+
+	.wheel-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.wheel-image-placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		font-size: 0.7rem;
+		color: var(--color-tertiary);
+	}
+
+	.wheel-title {
+		margin: 0.45rem 0 0;
+		font-size: 0.72rem;
+		line-height: 1.2;
+		color: var(--color-tertiary-darkest);
+		display: -webkit-box;
+		overflow: hidden;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
 	}
 
 	.picked-hero {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -996,24 +996,9 @@
 		margin-inline: auto;
 		padding: var(--bookcase-padding-block) 0 1.35rem;
 		border: clamp(0.75rem, 1.5vw, 1rem) solid #5f2f19;
-		background:
-			repeating-linear-gradient(
-				8deg,
-				rgb(255 229 176 / 0.1) 0 2px,
-				transparent 2px 18px,
-				rgb(60 25 10 / 0.1) 18px 20px,
-				transparent 20px 42px
-			),
-			repeating-linear-gradient(
-				92deg,
-				transparent 0 34px,
-				rgb(70 29 11 / 0.08) 34px 36px,
-				transparent 36px 76px
-			),
-			radial-gradient(ellipse at 18% 20%, rgb(255 224 165 / 0.16), transparent 30%),
-			radial-gradient(ellipse at 78% 68%, rgb(54 24 10 / 0.16), transparent 34%),
-			linear-gradient(90deg, rgb(52 23 10 / 0.22), transparent 10%, transparent 90%, rgb(52 23 10 / 0.22)),
-			#965229;
+		background-color: #8b4723;
+		background-image: var(--wood-grain-texture);
+		background-size: 260px 120px;
 		box-shadow:
 			inset 0 0 0 3px rgb(255 235 190 / 0.12),
 			inset 0 0 2rem rgb(50 22 9 / 0.24),
@@ -1025,6 +1010,7 @@
 		--shelf-board-height: 2.35rem;
 		--shelf-row-gap: 1.15rem;
 		--shelf-row-height: clamp(13.25rem, 20vw, 15.75rem);
+		--wood-grain-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='120' viewBox='0 0 260 120'%3E%3Cg fill='none' stroke-linecap='round'%3E%3Cpath d='M-24 16 C22 5 56 27 102 15 S192 7 284 20' stroke='%23f3c987' stroke-opacity='.22' stroke-width='3'/%3E%3Cpath d='M-18 34 C42 24 76 46 132 33 S218 27 278 42' stroke='%23532513' stroke-opacity='.18' stroke-width='2'/%3E%3Cpath d='M-26 58 C32 46 66 68 118 56 S202 49 286 64' stroke='%23f8d697' stroke-opacity='.16' stroke-width='2.4'/%3E%3Cpath d='M-22 84 C46 74 92 98 152 84 S224 78 284 94' stroke='%23451f0f' stroke-opacity='.2' stroke-width='2.2'/%3E%3Cpath d='M-14 106 C34 96 72 116 126 106 S210 98 278 112' stroke='%23f0be75' stroke-opacity='.14' stroke-width='2'/%3E%3Cellipse cx='72' cy='63' rx='28' ry='9' stroke='%23451f0f' stroke-opacity='.17' stroke-width='2'/%3E%3Cellipse cx='72' cy='63' rx='13' ry='4' stroke='%23f7d28f' stroke-opacity='.13' stroke-width='1.5'/%3E%3Cellipse cx='190' cy='27' rx='20' ry='6' stroke='%23451f0f' stroke-opacity='.14' stroke-width='1.6'/%3E%3C/g%3E%3C/svg%3E");
 	}
 
 	.games-flex::before {
@@ -1033,13 +1019,7 @@
 		z-index: 0;
 		inset: var(--bookcase-padding-block) 0 1.35rem;
 		background:
-			repeating-linear-gradient(
-				5deg,
-				rgb(255 226 174 / 0.13) 0 2px,
-				transparent 2px 24px,
-				rgb(66 28 11 / 0.12) 24px 26px,
-				transparent 26px 52px
-			),
+			var(--wood-grain-texture),
 			repeating-linear-gradient(
 				to bottom,
 				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
@@ -1055,6 +1035,9 @@
 				transparent calc(var(--shelf-row-height) + 0.35rem)
 					calc(var(--shelf-row-height) + var(--shelf-row-gap))
 			);
+		background-size:
+			260px 120px,
+			auto;
 		pointer-events: none;
 	}
 

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -990,7 +990,7 @@
 		grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
 		grid-auto-rows: var(--shelf-row-height);
 		align-items: stretch;
-		gap: 0.85rem 0;
+		gap: var(--shelf-row-gap) 0;
 		max-width: 1400px;
 		margin-inline: auto;
 		padding: 1rem 0 1.35rem;
@@ -1013,6 +1013,25 @@
 			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
 		--shelf-row-height: clamp(13rem, 20vw, 15.5rem);
 		--shelf-board-height: 2.25rem;
+		--shelf-row-gap: 0.85rem;
+		--game-side-gap: 0.35rem;
+	}
+
+	.games-flex::before {
+		content: '';
+		position: absolute;
+		z-index: -1;
+		inset: 1rem 0 1.35rem;
+		background: repeating-linear-gradient(
+			to bottom,
+			transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
+			#7b3d20 calc(var(--shelf-row-height) - var(--shelf-board-height))
+				calc(var(--shelf-row-height) - 0.95rem),
+			#9a5529 calc(var(--shelf-row-height) - 0.95rem) calc(var(--shelf-row-height) - 0.42rem),
+			#3d1d10 calc(var(--shelf-row-height) - 0.42rem) var(--shelf-row-height),
+			transparent var(--shelf-row-height) calc(var(--shelf-row-height) + var(--shelf-row-gap))
+		);
+		pointer-events: none;
 	}
 
 	.game-card-wrap {
@@ -1023,11 +1042,8 @@
 		justify-content: center;
 		width: 100%;
 		height: 100%;
-		padding-inline: 0.35rem;
-		border-bottom: var(--shelf-board-height) solid #7b3d20;
-		box-shadow:
-			inset 0 -0.42rem 0 #3d1d10,
-			inset 0 -0.95rem 0 #9a5529;
+		padding-inline: var(--game-side-gap);
+		padding-bottom: calc(var(--shelf-board-height) + 0.2rem);
 		background:
 			linear-gradient(
 				to bottom,

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -302,15 +302,6 @@
 	<div class="board-games-page">
 		<header class="page-header">
 			<h1>Board Game Collection</h1>
-			<p class="collection-owner font-oswald">
-				Viewing collection for <span class="username">{data.username}</span>
-			</p>
-			{#if !data.error && data.games.length > 0}
-				<p class="collection-stats">
-					{data.total}
-					{data.total === 1 ? 'game' : 'games'} in collection
-				</p>
-			{/if}
 		</header>
 
 		{#if data.error}
@@ -377,10 +368,15 @@
 						<option value="180">3+</option>
 					</select>
 				</div>
-				<span class="filter-count" aria-live="polite">
-					{displayedGames.length}
-					{displayedGames.length === 1 ? 'game' : 'games'} displaying
-				</span>
+				<div class="collection-count" aria-live="polite">
+					<span class="collection-count-value">{displayedGames.length}</span>
+					<span class="collection-count-label">
+						{displayedGames.length === 1 ? 'match' : 'matches'}
+						{#if displayedGames.length !== data.total}
+							of {data.total}
+						{/if}
+					</span>
+				</div>
 				<div class="controls-actions">
 					{#if pickedGame && !isSpinning}
 						<button type="button" class="collection-btn font-oswald" onclick={clearPick}>
@@ -598,25 +594,7 @@
 		font-family: var(--font-special-elite);
 		font-size: var(--fs-l);
 		color: var(--color-primary-darker);
-		margin: 0 0 0.5rem 0;
-	}
-
-	.collection-owner {
-		font-size: var(--fs-base);
-		color: var(--color-tertiary-darker);
-		margin: 0 0 0.25rem;
-	}
-
-	.username {
-		color: var(--color-primary);
-		font-weight: 600;
-	}
-
-	.collection-stats {
-		font-family: var(--font-oswald);
-		font-size: var(--fs-xs);
-		color: var(--color-tertiary);
-		margin: 0 0 1.25rem;
+		margin: 0;
 	}
 
 	.controls-panel {
@@ -688,22 +666,6 @@
 		gap: 0.25rem;
 	}
 
-	.filter-count {
-		font-size: 0.85rem;
-		color: var(--color-tertiary-darker);
-		white-space: nowrap;
-	}
-
-	.filter-count::before {
-		content: '';
-		display: inline-block;
-		width: 1px;
-		height: 1.1em;
-		margin-inline: 0.35rem 0.65rem;
-		background: var(--color-tertiary-lighter);
-		vertical-align: middle;
-	}
-
 	.filter-label {
 		font-size: 0.8rem;
 		text-transform: uppercase;
@@ -719,6 +681,33 @@
 		color: var(--color-tertiary-darkest);
 		cursor: pointer;
 		min-width: 10rem;
+	}
+
+	.collection-count {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-self: stretch;
+		min-width: 6.5rem;
+		padding: 0.45rem 0.75rem;
+		text-align: center;
+		color: var(--color-tertiary-darker);
+		border: 1px solid var(--color-tertiary-lighter);
+		background: rgb(255 255 255 / 0.72);
+	}
+
+	.collection-count-value {
+		font-family: var(--font-special-elite);
+		font-size: clamp(1.15rem, 2vw, 1.4rem);
+		line-height: 1;
+		color: var(--color-primary-darker);
+	}
+
+	.collection-count-label {
+		margin-top: 0.2rem;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
 	}
 
 	.filter-empty {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -351,6 +351,11 @@
 						Find me a game
 					{/if}
 				</button>
+				{#if pickedGame && !isSpinning}
+					<button type="button" class="collection-btn font-oswald" onclick={clearPick}>
+						View full collection
+					</button>
+				{/if}
 			</div>
 		{/if}
 
@@ -397,6 +402,7 @@
 					{@const g = centeredSpinGame}
 					<div class="wheel-result">
 						<div class="picked-meta">
+							<p class="result-eyebrow font-oswald">Tonight's game</p>
 							<h2 class="picked-title font-special-elite">{g.name ?? 'Game'}</h2>
 							{#if data.stats === 1 && g.stats}
 								<dl class="picked-dl font-oswald">
@@ -430,6 +436,10 @@
 										</dd>
 									</div>
 								</dl>
+							{:else}
+								<p class="result-note font-oswald">
+									Fetch full details to see player count, play time, and ratings here.
+								</p>
 							{/if}
 							<div class="picked-actions">
 								<a
@@ -441,7 +451,7 @@
 									Open on BoardGameGeek
 								</a>
 								<button type="button" class="picked-back font-oswald" onclick={clearPick}>
-									Back to collection
+									View full collection
 								</button>
 							</div>
 						</div>
@@ -672,7 +682,9 @@
 
 	.pick-row {
 		display: flex;
+		flex-wrap: wrap;
 		justify-content: center;
+		gap: 0.65rem;
 		margin-block-start: 1rem;
 	}
 
@@ -698,6 +710,25 @@
 	.pick-btn:disabled {
 		opacity: 0.45;
 		cursor: not-allowed;
+	}
+
+	.collection-btn {
+		padding: 0.55rem 1.1rem;
+		font-size: 0.85rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		background: var(--color-white-lightest);
+		color: var(--color-tertiary-darkest);
+		border: 2px solid var(--color-tertiary-lighter);
+		cursor: pointer;
+		transition:
+			border-color 0.2s,
+			transform 0.15s ease;
+	}
+
+	.collection-btn:hover {
+		border-color: var(--color-primary);
+		transform: translateY(-2px);
 	}
 
 	.pick-wheel {
@@ -851,8 +882,12 @@
 	.wheel-result {
 		max-width: 34rem;
 		margin: 1.75rem auto 0;
-		padding: 1.15rem 1rem;
-		border-top: 2px solid var(--color-primary);
+		padding: 1.25rem;
+		background:
+			linear-gradient(135deg, rgb(255 255 255 / 0.92), rgb(255 255 255 / 0.76)),
+			var(--color-white-lightest);
+		border: 2px solid var(--color-primary);
+		box-shadow: 6px 6px 0 rgb(0 0 0 / 0.12);
 		animation: wheel-result-in 0.28s ease-out both;
 	}
 
@@ -882,53 +917,77 @@
 		color: var(--color-tertiary-darker);
 	}
 
-	.picked-meta {
-		flex: 1;
-		min-width: 0;
-	}
-
 	.picked-title {
-		margin: 0 0 0.75rem;
-		font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+		margin: 0;
+		font-size: clamp(1.35rem, 2.75vw, 1.8rem);
 		color: var(--color-primary-darker);
 		line-height: 1.2;
 	}
 
+	.picked-meta {
+		max-width: 38rem;
+		margin-inline: auto;
+	}
+
+	.result-eyebrow {
+		margin: 0 0 0.25rem;
+		font-family: var(--font-oswald);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--color-primary);
+	}
+
+	.result-note {
+		margin: 1rem auto 1.25rem;
+		max-width: 24rem;
+		padding: 0.8rem 1rem;
+		color: var(--color-tertiary-darker);
+		background: rgb(255 255 255 / 0.72);
+		border: 1px solid var(--color-tertiary-lighter);
+	}
+
 	.picked-dl {
-		margin: 0 0 1.25rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.35rem;
-		font-size: 0.85rem;
+		margin: 1rem 0 1.25rem;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(7.25rem, 1fr));
+		gap: 0.65rem;
 		color: var(--color-tertiary-darker);
 	}
 
 	.picked-dl-row {
 		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		gap: 0.35rem 0.75rem;
-	}
-
-	@media (min-width: 640px) {
-		.picked-dl-row {
-			justify-content: flex-start;
-		}
+		flex-direction: column;
+		gap: 0.2rem;
+		padding: 0.65rem 0.75rem;
+		text-align: left;
+		background: rgb(255 255 255 / 0.72);
+		border: 1px solid var(--color-tertiary-lighter);
+		box-shadow: 3px 3px 0 rgb(0 0 0 / 0.08);
 	}
 
 	.picked-dl-row dt {
 		margin: 0;
-		font-weight: 600;
+		font-family: var(--font-oswald);
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
 		color: var(--color-tertiary);
 	}
 
 	.picked-dl-row dd {
 		margin: 0;
+		font-family: var(--font-special-elite);
+		font-size: clamp(1rem, 1.75vw, 1.2rem);
+		line-height: 1.15;
+		color: var(--color-tertiary-darkest);
 	}
 
 	.picked-dl-sub {
 		display: block;
-		font-size: 0.75rem;
+		margin-top: 0.2rem;
+		font-family: var(--font-oswald);
+		font-size: 0.7rem;
 		color: var(--color-tertiary);
 	}
 
@@ -936,14 +995,8 @@
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
-		gap: 0.65rem;
+		gap: 0.75rem;
 		align-items: center;
-	}
-
-	@media (min-width: 640px) {
-		.picked-actions {
-			justify-content: flex-start;
-		}
 	}
 
 	.picked-bgg-link {
@@ -956,18 +1009,20 @@
 		font-size: 0.85rem;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
-		background: transparent;
+		background: var(--color-white-lightest);
 		color: var(--color-tertiary-darker);
-		border: 1px solid var(--color-tertiary-lighter);
+		border: 2px solid var(--color-tertiary-lighter);
 		cursor: pointer;
 		transition:
 			background 0.2s,
-			border-color 0.2s;
+			border-color 0.2s,
+			transform 0.15s ease;
 	}
 
 	.picked-back:hover {
 		background: var(--color-white-lightest);
 		border-color: var(--color-tertiary);
+		transform: translateY(-2px);
 	}
 
 	.games-flex {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -247,6 +247,10 @@
 	function getBgStatsAddPlayHref(game: BggGame): string {
 		return `https://app.bgstatsapp.com/addPlay.html?gameId=${encodeURIComponent(String(game.id))}`;
 	}
+
+	function getGamePopoverId(game: BggGame, index: number): string {
+		return `game-popover-${game.id}-${index}`;
+	}
 </script>
 
 <Panel hasBorder hasTexture={false}>
@@ -459,8 +463,15 @@
 				{/if}
 				{#each displayedGames as game, i (`${game.id}-${i}`)}
 					{@const g = game as BggGame}
+					{@const popoverId = getGamePopoverId(g, i)}
 					<div class="game-card-wrap">
-						<div class="game-popover font-oswald" role="tooltip">
+						<div
+							id={popoverId}
+							class="game-popover font-oswald"
+							popover="auto"
+							role="dialog"
+							aria-label={g.name ? `${g.name} details` : 'Game details'}
+						>
 							<p class="game-popover-title">{g.name ?? 'Game'}</p>
 							<dl class="game-popover-dl">
 								<dt>Your plays</dt>
@@ -485,12 +496,20 @@
 									{/if}
 								</dd>
 							</dl>
+							<a
+								class="game-popover-link lookup-btn font-oswald"
+								href="https://boardgamegeek.com/boardgame/{g.id}"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Open on BGG
+							</a>
 						</div>
-						<a
-							href="https://boardgamegeek.com/boardgame/{g.id}"
-							target="_blank"
-							rel="noopener noreferrer"
+						<button
+							type="button"
 							class="game-card"
+							aria-haspopup="dialog"
+							popovertarget={popoverId}
 						>
 							{#if g.thumbnail}
 								<img src={g.image} alt={g.name ?? ''} class="game-image" loading="lazy" />
@@ -499,7 +518,7 @@
 									<span>No Image</span>
 								</div>
 							{/if}
-						</a>
+						</button>
 					</div>
 				{/each}
 			</div>
@@ -1054,21 +1073,9 @@
 		padding-bottom: calc(var(--shelf-board-height) + 0.38rem);
 	}
 
-	.game-card-wrap:hover .game-popover,
-	.game-card-wrap:focus-within .game-popover {
-		opacity: 1;
-		visibility: visible;
-		pointer-events: auto;
-		transform: translate(-50%, -0.35rem);
-	}
-
 	.game-popover {
-		position: absolute;
-		z-index: 20;
-		left: 50%;
-		bottom: calc(100% + 0.55rem);
-		transform: translate(-50%, 0);
 		width: min(15.5rem, 78vw);
+		max-width: calc(100vw - 2rem);
 		padding: 0.8rem 0.9rem;
 		font-size: 0.74rem;
 		line-height: 1.35;
@@ -1081,25 +1088,15 @@
 			5px 5px 0 var(--color-primary-darker),
 			0 10px 22px rgb(0 0 0 / 0.28);
 		opacity: 0;
-		visibility: hidden;
-		pointer-events: none;
+		transform: translateY(0.35rem);
 		transition:
 			opacity 0.15s ease,
-			transform 0.15s ease,
-			visibility 0.15s ease;
+			transform 0.15s ease;
 	}
 
-	.game-popover::after {
-		content: '';
-		position: absolute;
-		left: 50%;
-		bottom: -8px;
-		transform: translateX(-50%) rotate(45deg);
-		width: 0.85rem;
-		height: 0.85rem;
-		background: var(--color-tertiary-darkest);
-		border-right: 2px solid var(--color-primary);
-		border-bottom: 2px solid var(--color-primary);
+	.game-popover:popover-open {
+		opacity: 1;
+		transform: translateY(0);
 	}
 
 	.game-popover-title {
@@ -1138,6 +1135,14 @@
 		font-size: 0.65rem;
 		color: var(--color-tertiary-lighter);
 		margin-top: 0.1rem;
+	}
+
+	.game-popover-link {
+		display: inline-block;
+		margin-block-start: 0.6rem;
+		color: var(--color-white-lightest);
+		text-decoration: underline;
+		text-underline-offset: 0.15em;
 	}
 
 	.game-card {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1036,48 +1036,53 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
 		grid-auto-rows: var(--shelf-row-height);
-		align-items: end;
-		gap: 0.75rem 0.85rem;
+		align-items: stretch;
+		gap: 0.85rem 0;
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 2.15rem;
+		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.35rem;
 		border: 7px solid #5f2f19;
 		background:
-			linear-gradient(90deg, rgb(52 23 10 / 0.18), transparent 8%, transparent 92%, rgb(52 23 10 / 0.18)),
 			repeating-linear-gradient(
-				to bottom,
-				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.18rem),
-				rgb(255 231 185 / 0.16) calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.18rem)
-					calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.24rem),
-				transparent calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.24rem)
-					calc(var(--shelf-row-height) - 0.9rem),
-				rgb(55 24 10 / 0.14) calc(var(--shelf-row-height) - 0.9rem)
-					calc(var(--shelf-row-height) - 0.84rem),
-				transparent calc(var(--shelf-row-height) - 0.84rem) var(--shelf-row-height)
+				0deg,
+				rgb(255 230 180 / 0.08) 0 1px,
+				transparent 1px 9px,
+				rgb(58 25 10 / 0.08) 9px 10px,
+				transparent 10px 24px
 			),
-			repeating-linear-gradient(
-				to bottom,
-				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
-				#bf733b calc(var(--shelf-row-height) - var(--shelf-board-height))
-					calc(var(--shelf-row-height) - 1rem),
-				#7b3d20 calc(var(--shelf-row-height) - 1rem)
-					calc(var(--shelf-row-height) - 0.28rem),
-				#3d1d10 calc(var(--shelf-row-height) - 0.28rem) var(--shelf-row-height)
-			),
+			radial-gradient(ellipse at 20% 18%, rgb(255 223 164 / 0.14), transparent 32%),
+			radial-gradient(ellipse at 78% 64%, rgb(54 24 10 / 0.16), transparent 34%),
+			linear-gradient(90deg, rgb(52 23 10 / 0.16), transparent 9%, transparent 91%, rgb(52 23 10 / 0.16)),
 			#925028;
 		box-shadow:
 			inset 0 0 0 2px rgb(255 255 255 / 0.1),
 			0 0.9rem 0 #3d1d10,
 			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
 		--shelf-row-height: clamp(13rem, 20vw, 15.5rem);
-		--shelf-board-height: 2.35rem;
+		--shelf-board-height: 2.25rem;
 	}
 
 	.game-card-wrap {
 		position: relative;
-		align-self: end;
-		justify-self: center;
-		padding-bottom: var(--shelf-board-height);
+		box-sizing: border-box;
+		display: flex;
+		align-items: flex-end;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		padding-inline: 0.35rem;
+		border-bottom: var(--shelf-board-height) solid #7b3d20;
+		box-shadow:
+			inset 0 -0.42rem 0 #3d1d10,
+			inset 0 -0.95rem 0 #9a5529;
+		background:
+			linear-gradient(
+				to bottom,
+				transparent 0 calc(100% - var(--shelf-board-height)),
+				rgb(255 225 172 / 0.16) calc(100% - var(--shelf-board-height) + 0.25rem)
+					calc(100% - var(--shelf-board-height) + 0.32rem),
+				transparent calc(100% - var(--shelf-board-height) + 0.32rem) 100%
+			);
 	}
 
 	.game-card-wrap:hover .game-popover,
@@ -1092,7 +1097,7 @@
 		position: absolute;
 		z-index: 20;
 		left: 50%;
-		bottom: calc(100% + 0.55rem);
+		bottom: calc(var(--shelf-board-height) + 100% - var(--shelf-row-height) + 0.55rem);
 		transform: translate(-50%, 0);
 		width: min(15.5rem, 78vw);
 		padding: 0.8rem 0.9rem;

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1040,28 +1040,26 @@
 		gap: 0.75rem 0.85rem;
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.5rem;
+		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.85rem;
 		border: 7px solid #5f2f19;
 		background:
-			linear-gradient(90deg, rgb(52 23 10 / 0.3), transparent 8%, transparent 92%, rgb(52 23 10 / 0.3)),
-			repeating-linear-gradient(90deg, rgb(255 255 255 / 0.08) 0 1px, transparent 1px 34px),
+			linear-gradient(90deg, rgb(52 23 10 / 0.18), transparent 8%, transparent 92%, rgb(52 23 10 / 0.18)),
 			repeating-linear-gradient(
 				to bottom,
 				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
-				#b86a34 calc(var(--shelf-row-height) - var(--shelf-board-height))
-					calc(var(--shelf-row-height) - 0.46rem),
-				#7a3d20 calc(var(--shelf-row-height) - 0.46rem)
-					calc(var(--shelf-row-height) - 0.1rem),
-				#3d1d10 calc(var(--shelf-row-height) - 0.1rem) var(--shelf-row-height)
+				#bf733b calc(var(--shelf-row-height) - var(--shelf-board-height))
+					calc(var(--shelf-row-height) - 0.8rem),
+				#7b3d20 calc(var(--shelf-row-height) - 0.8rem)
+					calc(var(--shelf-row-height) - 0.22rem),
+				#3d1d10 calc(var(--shelf-row-height) - 0.22rem) var(--shelf-row-height)
 			),
-			linear-gradient(180deg, #a85e2f 0%, #81411f 100%);
+			#925028;
 		box-shadow:
 			inset 0 0 0 2px rgb(255 255 255 / 0.1),
-			inset 0 0 2rem rgb(50 22 9 / 0.22),
-			0 0.7rem 0 #3d1d10,
+			0 0.9rem 0 #3d1d10,
 			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
 		--shelf-row-height: clamp(12.5rem, 19vw, 14.75rem);
-		--shelf-board-height: 1.45rem;
+		--shelf-board-height: 2rem;
 	}
 
 	.game-card-wrap {
@@ -1174,20 +1172,15 @@
 			box-shadow 0.2s ease,
 			filter 0.2s ease;
 		overflow: hidden;
-		border: 3px solid #efe1c7;
-		background: var(--color-white-lightest);
-		box-shadow:
-			0 0.25rem 0 rgb(55 24 11 / 0.38),
-			0 0.7rem 0.85rem rgb(0 0 0 / 0.22);
+		background: transparent;
+		box-shadow: 0 0.7rem 0.85rem rgb(0 0 0 / 0.22);
 		transform-origin: bottom center;
 	}
 
 	.game-card:hover,
 	.game-card:focus-visible {
 		transform: translateY(-8px) rotate(-1deg);
-		box-shadow:
-			0 0 0 3px var(--color-primary),
-			0 0.85rem 1rem rgb(0 0 0 / 0.3);
+		box-shadow: 0 0.85rem 1rem rgb(0 0 0 / 0.3);
 		filter: saturate(1.05);
 	}
 

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -38,7 +38,6 @@
 	const SPIN_VISIBLE_RADIUS = 2;
 	const SPIN_MIN_TICKS = 28;
 	const SPIN_EXTRA_TICKS = 18;
-	const SPIN_SETTLE_DELAY_MS = 450;
 
 	$effect(() => {
 		lookupUsername = data.username;
@@ -175,6 +174,8 @@
 		});
 	}
 
+	const centeredSpinGame = $derived(spinGames[highlightedSpinIndex] ?? null);
+
 	function scheduleSpinTick(totalTicks: number) {
 		const progress = spinTick / totalTicks;
 		const delay = 55 + Math.pow(progress, 3) * 190;
@@ -188,13 +189,9 @@
 			highlightedSpinIndex = nextIndex;
 
 			if (spinTick >= totalTicks) {
-				const selectedGame = spinGames[nextIndex] ?? null;
 				clearSpinTimer();
-				spinTimeout = setTimeout(() => {
-					spinTimeout = null;
-					isSpinning = false;
-					pickedGame = selectedGame;
-				}, SPIN_SETTLE_DELAY_MS);
+				isSpinning = false;
+				pickedGame = spinGames[nextIndex] ?? null;
 				return;
 			}
 
@@ -346,17 +343,32 @@
 					disabled={displayedGames.length === 0 || isSpinning}
 					onclick={pickRandomGame}
 				>
-					{isSpinning ? 'Spinning...' : 'Find me a game'}
+					{#if isSpinning}
+						Spinning...
+					{:else if pickedGame}
+						Spin again
+					{:else}
+						Find me a game
+					{/if}
 				</button>
 			</div>
 		{/if}
 
-		{#if isSpinning}
-			<section class="pick-wheel" aria-live="polite" aria-busy="true">
-				<p class="picked-kicker font-oswald">Game roulette</p>
+		{#if isSpinning || pickedGame}
+			<section
+				class="pick-wheel"
+				class:pick-wheel--settled={pickedGame && !isSpinning}
+				aria-live="polite"
+				aria-busy={isSpinning}
+			>
+				<p class="picked-kicker font-oswald">{isSpinning ? 'Game roulette' : 'Your pick'}</p>
 				<p class="picked-tagline font-special-elite">
-					Spinning {displayedGames.length}
-					{displayedGames.length === 1 ? 'eligible game' : 'eligible games'}...
+					{#if isSpinning}
+						Spinning {displayedGames.length}
+						{displayedGames.length === 1 ? 'eligible game' : 'eligible games'}...
+					{:else}
+						The wheel has spoken.
+					{/if}
 				</p>
 				<div class="wheel-window">
 					<div class="wheel-pointer" aria-hidden="true"></div>
@@ -380,70 +392,61 @@
 						{/each}
 					</div>
 				</div>
-			</section>
-		{:else if pickedGame}
-			{@const g = pickedGame}
-			<section class="picked-hero" aria-live="polite">
-				<p class="picked-kicker font-oswald">Your pick</p>
-				<p class="picked-tagline font-special-elite">Here—go play this.</p>
-				<div class="picked-card">
-					<div class="picked-image-wrap">
-						{#if g.thumbnail && g.image}
-							<img class="picked-image" src={g.image} alt={g.name ?? 'Game cover'} loading="lazy" />
-						{:else}
-							<div class="picked-placeholder font-oswald">No image</div>
-						{/if}
-					</div>
-					<div class="picked-meta">
-						<h2 class="picked-title font-special-elite">{g.name ?? 'Game'}</h2>
-						{#if data.stats === 1 && g.stats}
-							<dl class="picked-dl font-oswald">
-								<div class="picked-dl-row">
-									<dt>Your plays</dt>
-									<dd>{g.numplays ?? '—'}</dd>
-								</div>
-								<div class="picked-dl-row">
-									<dt>Players</dt>
-									<dd>
-										{#if g.stats.minplayers != null && g.stats.maxplayers != null}
-											{g.stats.minplayers}–{g.stats.maxplayers}
-										{:else}
-											—
-										{/if}
-									</dd>
-								</div>
-								<div class="picked-dl-row">
-									<dt>Play time</dt>
-									<dd>{formatPlayTime(g)}</dd>
-								</div>
-								<div class="picked-dl-row">
-									<dt>Avg rating</dt>
-									<dd>
-										{formatAvg(g.stats.rating?.average)}
-										{#if g.stats.rating?.usersrated != null}
-											<span class="picked-dl-sub">
-												({g.stats.rating.usersrated.toLocaleString()} votes)
-											</span>
-										{/if}
-									</dd>
-								</div>
-							</dl>
-						{/if}
-						<div class="picked-actions">
-							<a
-								class="picked-bgg-link lookup-btn font-oswald"
-								href="https://boardgamegeek.com/boardgame/{g.id}"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Open on BoardGameGeek
-							</a>
-							<button type="button" class="picked-back font-oswald" onclick={clearPick}>
-								Back to collection
-							</button>
+
+				{#if pickedGame && !isSpinning && centeredSpinGame}
+					{@const g = centeredSpinGame}
+					<div class="wheel-result">
+						<div class="picked-meta">
+							<h2 class="picked-title font-special-elite">{g.name ?? 'Game'}</h2>
+							{#if data.stats === 1 && g.stats}
+								<dl class="picked-dl font-oswald">
+									<div class="picked-dl-row">
+										<dt>Your plays</dt>
+										<dd>{g.numplays ?? '—'}</dd>
+									</div>
+									<div class="picked-dl-row">
+										<dt>Players</dt>
+										<dd>
+											{#if g.stats.minplayers != null && g.stats.maxplayers != null}
+												{g.stats.minplayers}–{g.stats.maxplayers}
+											{:else}
+												—
+											{/if}
+										</dd>
+									</div>
+									<div class="picked-dl-row">
+										<dt>Play time</dt>
+										<dd>{formatPlayTime(g)}</dd>
+									</div>
+									<div class="picked-dl-row">
+										<dt>Avg rating</dt>
+										<dd>
+											{formatAvg(g.stats.rating?.average)}
+											{#if g.stats.rating?.usersrated != null}
+												<span class="picked-dl-sub">
+													({g.stats.rating.usersrated.toLocaleString()} votes)
+												</span>
+											{/if}
+										</dd>
+									</div>
+								</dl>
+							{/if}
+							<div class="picked-actions">
+								<a
+									class="picked-bgg-link lookup-btn font-oswald"
+									href="https://boardgamegeek.com/boardgame/{g.id}"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Open on BoardGameGeek
+								</a>
+								<button type="button" class="picked-back font-oswald" onclick={clearPick}>
+									Back to collection
+								</button>
+							</div>
 						</div>
 					</div>
-				</div>
+				{/if}
 			</section>
 		{:else}
 			<div class="games-flex">
@@ -798,6 +801,15 @@
 		box-shadow: 0 0 0 4px var(--color-primary-darker), 8px 8px 0 rgb(0 0 0 / 0.2);
 	}
 
+	.pick-wheel--settled .wheel-slot:not(.wheel-slot--active) {
+		opacity: 0.16;
+		transform: scale(0.72);
+	}
+
+	.pick-wheel--settled .wheel-slot--active {
+		transform: scale(1.14);
+	}
+
 	.wheel-image-frame {
 		aspect-ratio: 1 / 1;
 		display: flex;
@@ -836,15 +848,24 @@
 		-webkit-line-clamp: 2;
 	}
 
-	.picked-hero {
-		margin-block-start: 1.75rem;
-		max-width: 42rem;
-		margin-inline: auto;
-		padding: 1.5rem 1.25rem 2rem;
-		text-align: center;
-		border: 3px solid var(--color-primary-darker);
-		background: var(--color-white-lightest);
-		box-shadow: 8px 8px 0 var(--color-primary);
+	.wheel-result {
+		max-width: 34rem;
+		margin: 1.75rem auto 0;
+		padding: 1.15rem 1rem;
+		border-top: 2px solid var(--color-primary);
+		animation: wheel-result-in 0.28s ease-out both;
+	}
+
+	@keyframes wheel-result-in {
+		from {
+			opacity: 0;
+			transform: translateY(-0.5rem);
+		}
+
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
 	}
 
 	.picked-kicker {
@@ -859,45 +880,6 @@
 		margin: 0 0 1.25rem;
 		font-size: clamp(1.1rem, 2vw, 1.35rem);
 		color: var(--color-tertiary-darker);
-	}
-
-	.picked-card {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 1.25rem;
-	}
-
-	@media (min-width: 640px) {
-		.picked-card {
-			flex-direction: row;
-			align-items: flex-start;
-			text-align: left;
-		}
-	}
-
-	.picked-image-wrap {
-		flex-shrink: 0;
-		width: 100%;
-		max-width: 220px;
-		border: 2px solid #a0522d;
-		overflow: hidden;
-		border-bottom: 15px solid #a0522d;
-	}
-
-	.picked-image {
-		width: 100%;
-		display: block;
-	}
-
-	.picked-placeholder {
-		min-height: 220px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-size: var(--fs-xs);
-		color: var(--color-tertiary);
-		background: var(--color-white-lightest);
 	}
 
 	.picked-meta {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -987,71 +987,87 @@
 		isolation: isolate;
 		margin-block-start: 1.75rem;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+		grid-template-columns: repeat(auto-fill, minmax(var(--game-cover-width), var(--game-cover-width)));
 		grid-auto-rows: var(--shelf-row-height);
 		align-items: stretch;
-		gap: var(--shelf-row-gap) 0;
+		justify-content: center;
+		gap: var(--shelf-row-gap) var(--game-gap);
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: 1rem 0 1.35rem;
-		border: 7px solid #5f2f19;
+		padding: var(--bookcase-padding-block) 0 1.35rem;
+		border: clamp(0.75rem, 1.5vw, 1rem) solid #5f2f19;
 		background:
 			repeating-linear-gradient(
-				0deg,
-				rgb(255 230 180 / 0.08) 0 1px,
-				transparent 1px 9px,
-				rgb(58 25 10 / 0.08) 9px 10px,
-				transparent 10px 24px
+				8deg,
+				rgb(255 229 176 / 0.1) 0 2px,
+				transparent 2px 18px,
+				rgb(60 25 10 / 0.1) 18px 20px,
+				transparent 20px 42px
 			),
-			radial-gradient(ellipse at 20% 18%, rgb(255 223 164 / 0.14), transparent 32%),
-			radial-gradient(ellipse at 78% 64%, rgb(54 24 10 / 0.16), transparent 34%),
-			linear-gradient(90deg, rgb(52 23 10 / 0.16), transparent 9%, transparent 91%, rgb(52 23 10 / 0.16)),
-			#925028;
+			repeating-linear-gradient(
+				92deg,
+				transparent 0 34px,
+				rgb(70 29 11 / 0.08) 34px 36px,
+				transparent 36px 76px
+			),
+			radial-gradient(ellipse at 18% 20%, rgb(255 224 165 / 0.16), transparent 30%),
+			radial-gradient(ellipse at 78% 68%, rgb(54 24 10 / 0.16), transparent 34%),
+			linear-gradient(90deg, rgb(52 23 10 / 0.22), transparent 10%, transparent 90%, rgb(52 23 10 / 0.22)),
+			#965229;
 		box-shadow:
-			inset 0 0 0 2px rgb(255 255 255 / 0.1),
-			0 0.9rem 0 #3d1d10,
+			inset 0 0 0 3px rgb(255 235 190 / 0.12),
+			inset 0 0 2rem rgb(50 22 9 / 0.24),
+			0 0.95rem 0 #3d1d10,
 			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
-		--shelf-row-height: clamp(13rem, 20vw, 15.5rem);
-		--shelf-board-height: 2.25rem;
-		--shelf-row-gap: 0.85rem;
-		--game-side-gap: 0.35rem;
+		--bookcase-padding-block: 1rem;
+		--game-cover-width: clamp(104px, 10vw, 132px);
+		--game-gap: 0.35rem;
+		--shelf-board-height: 2.35rem;
+		--shelf-row-gap: 1.15rem;
+		--shelf-row-height: clamp(13.25rem, 20vw, 15.75rem);
 	}
 
 	.games-flex::before {
 		content: '';
 		position: absolute;
-		z-index: -1;
-		inset: 1rem 0 1.35rem;
-		background: repeating-linear-gradient(
-			to bottom,
-			transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
-			#7b3d20 calc(var(--shelf-row-height) - var(--shelf-board-height))
-				calc(var(--shelf-row-height) - 0.95rem),
-			#9a5529 calc(var(--shelf-row-height) - 0.95rem) calc(var(--shelf-row-height) - 0.42rem),
-			#3d1d10 calc(var(--shelf-row-height) - 0.42rem) var(--shelf-row-height),
-			transparent var(--shelf-row-height) calc(var(--shelf-row-height) + var(--shelf-row-gap))
-		);
+		z-index: 0;
+		inset: var(--bookcase-padding-block) 0 1.35rem;
+		background:
+			repeating-linear-gradient(
+				5deg,
+				rgb(255 226 174 / 0.13) 0 2px,
+				transparent 2px 24px,
+				rgb(66 28 11 / 0.12) 24px 26px,
+				transparent 26px 52px
+			),
+			repeating-linear-gradient(
+				to bottom,
+				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
+				#d18a47 calc(var(--shelf-row-height) - var(--shelf-board-height))
+					calc(var(--shelf-row-height) - 1.95rem),
+				#b76d35 calc(var(--shelf-row-height) - 1.95rem)
+					calc(var(--shelf-row-height) - 0.95rem),
+				#7a3a1d calc(var(--shelf-row-height) - 0.95rem)
+					calc(var(--shelf-row-height) - 0.32rem),
+				#3d1d10 calc(var(--shelf-row-height) - 0.32rem) var(--shelf-row-height),
+				rgb(0 0 0 / 0.18) var(--shelf-row-height)
+					calc(var(--shelf-row-height) + 0.35rem),
+				transparent calc(var(--shelf-row-height) + 0.35rem)
+					calc(var(--shelf-row-height) + var(--shelf-row-gap))
+			);
 		pointer-events: none;
 	}
 
 	.game-card-wrap {
 		position: relative;
 		box-sizing: border-box;
+		z-index: 1;
 		display: flex;
 		align-items: flex-end;
 		justify-content: center;
 		width: 100%;
 		height: 100%;
-		padding-inline: var(--game-side-gap);
-		padding-bottom: calc(var(--shelf-board-height) + 0.2rem);
-		background:
-			linear-gradient(
-				to bottom,
-				transparent 0 calc(100% - var(--shelf-board-height)),
-				rgb(255 225 172 / 0.16) calc(100% - var(--shelf-board-height) + 0.25rem)
-					calc(100% - var(--shelf-board-height) + 0.32rem),
-				transparent calc(100% - var(--shelf-board-height) + 0.32rem) 100%
-			);
+		padding-bottom: calc(var(--shelf-board-height) + 0.38rem);
 	}
 
 	.game-card-wrap:hover .game-popover,
@@ -1143,8 +1159,11 @@
 	.game-card {
 		position: relative;
 		z-index: 1;
-		display: block;
-		width: clamp(96px, 12vw, 145px);
+		display: flex;
+		justify-content: center;
+		align-items: flex-end;
+		width: var(--game-cover-width);
+		max-height: calc(var(--shelf-row-height) - var(--shelf-board-height) - 1rem);
 		flex-shrink: 0;
 		text-decoration: none;
 		transition:
@@ -1165,13 +1184,21 @@
 	}
 
 	.game-image {
-		width: 100%;
 		display: block;
+		width: auto;
+		max-width: 100%;
+		max-height: calc(var(--shelf-row-height) - var(--shelf-board-height) - 1rem);
+		object-fit: contain;
+	}
+
+	.game-card:hover .game-image,
+	.game-card:focus-visible .game-image {
+		filter: saturate(1.05);
 	}
 
 	.game-image-placeholder {
 		width: 100%;
-		height: 150px;
+		height: min(150px, calc(var(--shelf-row-height) - var(--shelf-board-height) - 1rem));
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -1181,8 +1208,9 @@
 	}
 
 	@media (max-width: 768px) {
-		.game-card {
-			width: 120px;
+		.games-flex {
+			--game-cover-width: 108px;
+			--shelf-row-height: 13.25rem;
 		}
 
 		.game-image-placeholder {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1040,33 +1040,44 @@
 		gap: 0.75rem 0.85rem;
 		max-width: 1400px;
 		margin-inline: auto;
-		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 1.85rem;
+		padding: 1rem clamp(0.75rem, 2vw, 1.25rem) 2.15rem;
 		border: 7px solid #5f2f19;
 		background:
 			linear-gradient(90deg, rgb(52 23 10 / 0.18), transparent 8%, transparent 92%, rgb(52 23 10 / 0.18)),
 			repeating-linear-gradient(
 				to bottom,
+				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.18rem),
+				rgb(255 231 185 / 0.16) calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.18rem)
+					calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.24rem),
+				transparent calc(var(--shelf-row-height) - var(--shelf-board-height) + 0.24rem)
+					calc(var(--shelf-row-height) - 0.9rem),
+				rgb(55 24 10 / 0.14) calc(var(--shelf-row-height) - 0.9rem)
+					calc(var(--shelf-row-height) - 0.84rem),
+				transparent calc(var(--shelf-row-height) - 0.84rem) var(--shelf-row-height)
+			),
+			repeating-linear-gradient(
+				to bottom,
 				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
 				#bf733b calc(var(--shelf-row-height) - var(--shelf-board-height))
-					calc(var(--shelf-row-height) - 0.8rem),
-				#7b3d20 calc(var(--shelf-row-height) - 0.8rem)
-					calc(var(--shelf-row-height) - 0.22rem),
-				#3d1d10 calc(var(--shelf-row-height) - 0.22rem) var(--shelf-row-height)
+					calc(var(--shelf-row-height) - 1rem),
+				#7b3d20 calc(var(--shelf-row-height) - 1rem)
+					calc(var(--shelf-row-height) - 0.28rem),
+				#3d1d10 calc(var(--shelf-row-height) - 0.28rem) var(--shelf-row-height)
 			),
 			#925028;
 		box-shadow:
 			inset 0 0 0 2px rgb(255 255 255 / 0.1),
 			0 0.9rem 0 #3d1d10,
 			0 1.15rem 1.5rem rgb(0 0 0 / 0.22);
-		--shelf-row-height: clamp(12.5rem, 19vw, 14.75rem);
-		--shelf-board-height: 2rem;
+		--shelf-row-height: clamp(13rem, 20vw, 15.5rem);
+		--shelf-board-height: 2.35rem;
 	}
 
 	.game-card-wrap {
 		position: relative;
 		align-self: end;
 		justify-self: center;
-		padding-bottom: calc(var(--shelf-board-height) - 0.2rem);
+		padding-bottom: var(--shelf-board-height);
 	}
 
 	.game-card-wrap:hover .game-popover,

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -545,14 +545,24 @@
 							{/if}
 						</dd>
 					</dl>
-					<a
-						class="game-popover-link lookup-btn font-oswald"
-						href="https://boardgamegeek.com/boardgame/{g.id}"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Open on BGG
-					</a>
+					<div class="game-popover-actions">
+						<a
+							class="game-popover-link game-popover-bgstats-link lookup-btn font-oswald"
+							href={getBgStatsAddPlayHref(g)}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Open in BG Stats
+						</a>
+						<a
+							class="game-popover-link lookup-btn font-oswald"
+							href="https://boardgamegeek.com/boardgame/{g.id}"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Open on BGG
+						</a>
+					</div>
 				</div>
 				<button
 					type="button"
@@ -1192,12 +1202,23 @@
 		margin-top: 0.1rem;
 	}
 
+	.game-popover-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-block-start: 0.6rem;
+	}
+
 	.game-popover-link {
 		display: inline-block;
-		margin-block-start: 0.6rem;
 		color: var(--color-white-lightest);
 		text-decoration: underline;
 		text-underline-offset: 0.15em;
+	}
+
+	.game-popover-bgstats-link {
+		background: var(--color-primary);
+		border-color: var(--color-primary);
 	}
 
 	.game-card {

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1078,7 +1078,7 @@
 	.games-flex::before {
 		content: '';
 		position: absolute;
-		z-index: 0;
+		z-index: 1;
 		inset: var(--bookcase-padding-block) 0 1.35rem;
 		background: repeating-linear-gradient(
 			to bottom,
@@ -1115,7 +1115,7 @@
 	.game-card-wrap {
 		position: relative;
 		box-sizing: border-box;
-		z-index: 1;
+		z-index: 2;
 		display: flex;
 		align-items: flex-end;
 		justify-content: center;

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -1061,8 +1061,6 @@
 		padding: var(--bookcase-padding-block) 0 1.35rem;
 		border: clamp(0.75rem, 1.5vw, 1rem) solid #5f2f19;
 		background-color: #8b4723;
-		background-image: var(--wood-grain-texture);
-		background-size: 360px 270px;
 		box-shadow:
 			inset 0 0 0 3px rgb(255 235 190 / 0.12),
 			inset 0 0 2rem rgb(50 22 9 / 0.24),
@@ -1082,27 +1080,35 @@
 		position: absolute;
 		z-index: 0;
 		inset: var(--bookcase-padding-block) 0 1.35rem;
-		background:
-			repeating-linear-gradient(
-				to bottom,
-				transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
-				#d18a47 calc(var(--shelf-row-height) - var(--shelf-board-height))
-					calc(var(--shelf-row-height) - 1.95rem),
-				#b76d35 calc(var(--shelf-row-height) - 1.95rem)
-					calc(var(--shelf-row-height) - 0.95rem),
-				#7a3a1d calc(var(--shelf-row-height) - 0.95rem)
-					calc(var(--shelf-row-height) - 0.32rem),
-				#3d1d10 calc(var(--shelf-row-height) - 0.32rem) var(--shelf-row-height),
-				rgb(0 0 0 / 0.18) var(--shelf-row-height)
-					calc(var(--shelf-row-height) + 0.35rem),
-				transparent calc(var(--shelf-row-height) + 0.35rem)
-					calc(var(--shelf-row-height) + var(--shelf-row-gap))
-			),
-			var(--wood-grain-texture);
-		background-blend-mode: normal, multiply;
-		background-size:
-			auto,
-			360px 270px;
+		background: repeating-linear-gradient(
+			to bottom,
+			transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
+			#d18a47 calc(var(--shelf-row-height) - var(--shelf-board-height))
+				calc(var(--shelf-row-height) - 1.95rem),
+			#b76d35 calc(var(--shelf-row-height) - 1.95rem)
+				calc(var(--shelf-row-height) - 0.95rem),
+			#7a3a1d calc(var(--shelf-row-height) - 0.95rem)
+				calc(var(--shelf-row-height) - 0.32rem),
+			#3d1d10 calc(var(--shelf-row-height) - 0.32rem) var(--shelf-row-height),
+			rgb(0 0 0 / 0.18) var(--shelf-row-height)
+				calc(var(--shelf-row-height) + 0.35rem),
+			transparent calc(var(--shelf-row-height) + 0.35rem)
+				calc(var(--shelf-row-height) + var(--shelf-row-gap))
+		);
+		pointer-events: none;
+	}
+
+	.games-flex::after {
+		content: '';
+		position: absolute;
+		z-index: 0;
+		inset: var(--bookcase-padding-block) 0 1.35rem;
+		background-image: var(--wood-grain-texture);
+		background-size: 360px 270px;
+		filter: invert(24%) sepia(39%) saturate(1017%) hue-rotate(343deg) brightness(82%)
+			contrast(87%);
+		mix-blend-mode: multiply;
+		opacity: 0.42;
 		pointer-events: none;
 	}
 

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -209,7 +209,10 @@
 		const totalTicks = SPIN_MIN_TICKS + Math.floor(Math.random() * SPIN_EXTRA_TICKS);
 
 		spinGames = wheelGames;
-		highlightedSpinIndex = positiveModulo(finalIndex - (totalTicks % wheelGames.length), wheelGames.length);
+		highlightedSpinIndex = positiveModulo(
+			finalIndex - (totalTicks % wheelGames.length),
+			wheelGames.length
+		);
 		spinTick = 0;
 		pickedGame = null;
 		isSpinning = true;
@@ -878,7 +881,9 @@
 		border-color: var(--color-primary);
 		opacity: 1;
 		transform: scale(1.08) rotate(0deg);
-		box-shadow: 0 0 0 4px var(--color-primary-darker), 8px 8px 0 rgb(0 0 0 / 0.2);
+		box-shadow:
+			0 0 0 4px var(--color-primary-darker),
+			8px 8px 0 rgb(0 0 0 / 0.2);
 	}
 
 	.pick-wheel--settled .wheel-slot:not(.wheel-slot--active) {
@@ -1061,7 +1066,10 @@
 		isolation: isolate;
 		margin-block-start: 1.75rem;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(var(--game-cover-width), var(--game-cover-width)));
+		grid-template-columns: repeat(
+			auto-fill,
+			minmax(var(--game-cover-width), var(--game-cover-width))
+		);
 		grid-auto-rows: var(--shelf-row-height);
 		align-items: stretch;
 		justify-content: center;
@@ -1095,13 +1103,10 @@
 			transparent 0 calc(var(--shelf-row-height) - var(--shelf-board-height)),
 			#d18a47 calc(var(--shelf-row-height) - var(--shelf-board-height))
 				calc(var(--shelf-row-height) - 1.95rem),
-			#b76d35 calc(var(--shelf-row-height) - 1.95rem)
-				calc(var(--shelf-row-height) - 0.95rem),
-			#7a3a1d calc(var(--shelf-row-height) - 0.95rem)
-				calc(var(--shelf-row-height) - 0.32rem),
+			#b76d35 calc(var(--shelf-row-height) - 1.95rem) calc(var(--shelf-row-height) - 0.95rem),
+			#7a3a1d calc(var(--shelf-row-height) - 0.95rem) calc(var(--shelf-row-height) - 0.32rem),
 			#3d1d10 calc(var(--shelf-row-height) - 0.32rem) var(--shelf-row-height),
-			rgb(0 0 0 / 0.18) var(--shelf-row-height)
-				calc(var(--shelf-row-height) + 0.35rem),
+			rgb(0 0 0 / 0.18) var(--shelf-row-height) calc(var(--shelf-row-height) + 0.35rem),
 			transparent calc(var(--shelf-row-height) + 0.35rem)
 				calc(var(--shelf-row-height) + var(--shelf-row-gap))
 		);
@@ -1115,8 +1120,7 @@
 		inset: var(--bookcase-padding-block) 0 1.35rem;
 		background-image: var(--wood-grain-texture);
 		background-size: 360px 270px;
-		filter: invert(24%) sepia(39%) saturate(1017%) hue-rotate(343deg) brightness(82%)
-			contrast(87%);
+		filter: invert(24%) sepia(39%) saturate(1017%) hue-rotate(343deg) brightness(82%) contrast(87%);
 		mix-blend-mode: multiply;
 		opacity: 0.42;
 		pointer-events: none;
@@ -1146,8 +1150,7 @@
 		line-height: 1.35;
 		color: var(--color-white-lightest);
 		background:
-			linear-gradient(135deg, rgb(255 255 255 / 0.06), transparent),
-			var(--color-tertiary-darkest);
+			linear-gradient(135deg, rgb(255 255 255 / 0.06), transparent), var(--color-tertiary-darkest);
 		border: 2px solid var(--color-primary);
 		box-shadow:
 			5px 5px 0 var(--color-primary-darker),

--- a/src/routes/(site)/board-games/+page.svelte
+++ b/src/routes/(site)/board-games/+page.svelte
@@ -552,7 +552,7 @@
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Open in BG Stats
+							BGStats
 						</a>
 						<a
 							class="game-popover-link lookup-btn font-oswald"
@@ -560,7 +560,7 @@
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Open on BGG
+							BGG
 						</a>
 					</div>
 				</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Always fetch full BoardGameGeek collection details and remove the Basic/Full detail selector
- Consolidate username lookup, filters, match count, "View full collection," and "Pick a game for me" into a compact controls panel
- Remove redundant header collection-owner/total text and replace the old count label with a compact matches/total status chip
- Move the bookcase collection outside the panel so the shelf has its own full-width area
- Replace instant board-game random pick with a short roulette-style spin through eligible games
- Show a centered five-slot reel with exactly two games on each side of the active selected slot
- Keep the reel visible after it stops, fade back the surrounding games, and reveal a polished winner/details card inline beneath the centered slot
- Add BGStats actions to both the post-spin result and each game popover, deep-linking to BG Stats Add Play for the selected BGG game id
- Redesign the collection view as a thicker framed wooden bookcase with fixed-width cover slots, tiny gaps between game boxes, full-width 3D shelf planks between rows, and a single recolored Openclipart tileable woodgrain layer behind the shelf planks
- Use native HTML popovers for game details, opened on hover/focus and anchored above the hovered cover
- Reset/cancel spin state when filters or collection data change
- Format the board games page with Prettier

## Testing
- `git diff --check`
- `prettier --write src/routes/(site)/board-games/+page.svelte` via temporary Node/Prettier toolchain
- Unable to run full `pnpm run check` in this cloud image because Node/pnpm are not installed on PATH
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8567ebba-8f7e-4c99-b42a-6b32818a9c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8567ebba-8f7e-4c99-b42a-6b32818a9c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

