### PR TITLE
Share target: review form and server action upload before Payload

### DIFF
--- a/src/lib/share-target-draft.server.ts
+++ b/src/lib/share-target-draft.server.ts
@@ -1,0 +1,90 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** HttpOnly cookie holding the opaque draft token after `POST /api/share-target`. */
+export const SHARE_TARGET_DRAFT_COOKIE = 'share_target_draft';
+
+export const DRAFT_MAX_BYTES = 15 * 1024 * 1024;
+export const DRAFT_MAX_AGE_MS = 15 * 60 * 1000;
+
+export type DraftMeta = {
+	originalName: string;
+	mimeType: string;
+	shareTitle: string;
+	shareText: string;
+	shareUrl: string;
+	createdAt: number;
+	/** Number of additional image files dropped (only first is kept). */
+	extraImagesDropped: number;
+};
+
+function draftDir() {
+	return join(tmpdir(), 'share-target-drafts');
+}
+
+function pathsFor(token: string) {
+	const base = join(draftDir(), token);
+	return { bin: base, meta: `${base}.meta.json` as const };
+}
+
+function isValidToken(token: string | undefined): token is string {
+	return typeof token === 'string' && /^[a-f0-9]{32}$/.test(token);
+}
+
+export async function saveDraft(args: {
+	buffer: Buffer;
+	meta: Omit<DraftMeta, 'createdAt'>;
+}): Promise<string> {
+	if (args.buffer.byteLength > DRAFT_MAX_BYTES) {
+		throw new Error('FILE_TOO_LARGE');
+	}
+	await mkdir(draftDir(), { recursive: true });
+	const token = randomBytes(16).toString('hex');
+	const { bin, meta } = pathsFor(token);
+	const fullMeta: DraftMeta = { ...args.meta, createdAt: Date.now() };
+	await writeFile(bin, args.buffer);
+	await writeFile(meta, JSON.stringify(fullMeta), 'utf8');
+	return token;
+}
+
+export async function readDraftMeta(token: string | undefined): Promise<DraftMeta | null> {
+	if (!isValidToken(token)) return null;
+	const { bin, meta } = pathsFor(token);
+	try {
+		const s = await stat(bin);
+		if (!s.isFile()) return null;
+		if (Date.now() - s.mtimeMs > DRAFT_MAX_AGE_MS) {
+			await deleteDraft(token);
+			return null;
+		}
+		const raw = await readFile(meta, 'utf8');
+		const parsed = JSON.parse(raw) as DraftMeta;
+		if (typeof parsed.originalName !== 'string') return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+export async function readDraftFile(
+	token: string | undefined
+): Promise<{ buffer: Buffer; meta: DraftMeta } | null> {
+	if (!isValidToken(token)) return null;
+	const meta = await readDraftMeta(token);
+	if (!meta) return null;
+	const { bin } = pathsFor(token);
+	try {
+		const buffer = await readFile(bin);
+		return { buffer, meta };
+	} catch {
+		return null;
+	}
+}
+
+export async function deleteDraft(token: string | undefined): Promise<void> {
+	if (!isValidToken(token)) return;
+	const { bin, meta } = pathsFor(token);
+	await Promise.allSettled([unlink(bin), unlink(meta)]);
+}

--- a/src/lib/share-target-payload-upload.server.ts
+++ b/src/lib/share-target-payload-upload.server.ts
@@ -1,0 +1,98 @@
+import type { ShareTargetDestination } from '$lib/share-target-destination';
+
+export function isImageFile(f: File): boolean {
+	if (typeof f.type === 'string' && f.type.startsWith('image/')) return true;
+	const name = f.name.toLowerCase();
+	return /\.(heic|heif|jpe?g|png|gif|webp|avif|bmp|tiff?)$/.test(name);
+}
+
+export function altFromShareContext(file: File, title: string, text: string, url: string): string {
+	const combined = [title, text, url]
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.join(' — ');
+	const base = combined || file.name.replace(/\.[^.]+$/, '') || 'Shared image';
+	return base.length > 500 ? base.slice(0, 497) + '…' : base;
+}
+
+export async function payloadCreateUpload(args: {
+	innerFetch: typeof fetch;
+	baseURL: string;
+	collection: 'media' | 'gallery-images';
+	fileBody: Blob;
+	filename: string;
+	payloadJson: Record<string, unknown>;
+}): Promise<{ ok: true; id: number } | { ok: false; message: string }> {
+	const formData = new FormData();
+	formData.append('file', args.fileBody, args.filename);
+	formData.append('_payload', JSON.stringify(args.payloadJson));
+
+	const res = await args.innerFetch(`${args.baseURL.replace(/\/$/, '')}/${args.collection}`, {
+		method: 'POST',
+		body: formData,
+		credentials: 'include'
+	});
+
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return { ok: false, message: `HTTP ${res.status}` };
+	}
+
+	if (!res.ok) {
+		const errObj = body as { errors?: { message?: string }[]; message?: string };
+		const first = errObj.errors?.[0]?.message ?? errObj.message ?? `HTTP ${res.status}`;
+		return { ok: false, message: first };
+	}
+
+	const doc = body as { doc?: { id?: number } };
+	const id = doc.doc?.id;
+	if (typeof id !== 'number') {
+		return { ok: false, message: 'Unexpected response from CMS' };
+	}
+	return { ok: true, id };
+}
+
+function buildGalleryImagePayload(albumId: number, alt: string): Record<string, unknown> {
+	return {
+		alt,
+		settings: {
+			visibility: 'AUTHENTICATED',
+			isNsfw: false
+		},
+		albums: [albumId]
+	};
+}
+
+function buildMediaPayload(alt: string): Record<string, unknown> {
+	return { alt };
+}
+
+export async function uploadForDestination(
+	innerFetch: typeof fetch,
+	baseURL: string,
+	dest: ShareTargetDestination,
+	fileBody: Blob,
+	filename: string,
+	alt: string
+): Promise<{ ok: true; id: number } | { ok: false; message: string }> {
+	if (dest.mode === 'media') {
+		return payloadCreateUpload({
+			innerFetch,
+			baseURL,
+			collection: 'media',
+			fileBody,
+			filename,
+			payloadJson: buildMediaPayload(alt)
+		});
+	}
+	return payloadCreateUpload({
+		innerFetch,
+		baseURL,
+		collection: 'gallery-images',
+		fileBody,
+		filename,
+		payloadJson: buildGalleryImagePayload(dest.albumId, alt)
+	});
+}

--- a/src/lib/site-manifest.json
+++ b/src/lib/site-manifest.json
@@ -31,6 +31,7 @@
 		}
 	],
 	"start_url": "/",
+	"scope": "/",
 	"display": "fullscreen",
 	"background_color": "#982929",
 	"theme_color": "#982929",
@@ -48,11 +49,20 @@
 					"accept": [
 						"image/*",
 						"image/jpeg",
+						".jpg",
+						".jpeg",
 						"image/png",
+						".png",
 						"image/webp",
+						".webp",
 						"image/gif",
+						".gif",
 						"image/heic",
-						"image/heif"
+						"image/heif",
+						".heic",
+						".heif",
+						"image/avif",
+						".avif"
 					]
 				}
 			]

--- a/src/routes/api/share-target/+server.ts
+++ b/src/routes/api/share-target/+server.ts
@@ -105,3 +105,6 @@ export const POST: RequestHandler = async ({ request, fetch, cookies, url: pageU
 	const next = new URL('/share-target/review', pageUrl);
 	throw redirect(303, next.href);
 };
+
+/** Some clients probe the share action with GET; only POST receives shares. */
+export const GET: RequestHandler = () => new Response(null, { status: 204 });

--- a/src/routes/api/share-target/+server.ts
+++ b/src/routes/api/share-target/+server.ts
@@ -1,11 +1,10 @@
 import { dev } from '$app/environment';
-import { createPayloadInnerFetch } from '$lib/payload';
 import {
-	parseShareTargetDestination,
-	SHARE_TARGET_DEST_COOKIE,
-	SHARE_TARGET_FLASH_COOKIE,
-	type ShareTargetDestination
-} from '$lib/share-target-destination';
+	DRAFT_MAX_BYTES,
+	SHARE_TARGET_DRAFT_COOKIE,
+	saveDraft
+} from '$lib/share-target-draft.server';
+import { isImageFile } from '$lib/share-target-payload-upload.server';
 import { redirect, type RequestHandler } from '@sveltejs/kit';
 
 function escapeHtml(s: string): string {
@@ -17,101 +16,8 @@ function escapeHtml(s: string): string {
 }
 
 function shareResultHtml(title: string, body: string, status: number): Response {
-	const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapeHtml(title)}</title></head><body style="font-family:system-ui,sans-serif;padding:1.5rem;max-width:40rem;margin:auto"><h1 style="font-size:1.25rem">${escapeHtml(title)}</h1><p>${escapeHtml(body)}</p><p><a href="/share-target">Share target settings</a> · <a href="/account/login">Sign in</a></p></body></html>`;
+	const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapeHtml(title)}</title></head><body style="font-family:system-ui,sans-serif;padding:1.5rem;max-width:40rem;margin:auto"><h1 style="font-size:1.25rem">${escapeHtml(title)}</h1><p>${escapeHtml(body)}</p><p><a href="/share-target">Share target</a> · <a href="/account/login">Sign in</a></p></body></html>`;
 	return new Response(html, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
-}
-
-function altFromShareContext(file: File, title: string, text: string, url: string): string {
-	const combined = [title, text, url]
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.join(' — ');
-	const base = combined || file.name.replace(/\.[^.]+$/, '') || 'Shared image';
-	return base.length > 500 ? base.slice(0, 497) + '…' : base;
-}
-
-function isImageFile(f: File): boolean {
-	if (typeof f.type === 'string' && f.type.startsWith('image/')) return true;
-	const name = f.name.toLowerCase();
-	return /\.(heic|heif|jpe?g|png|gif|webp|avif|bmp|tiff?)$/.test(name);
-}
-
-async function payloadCreateUpload(args: {
-	innerFetch: typeof fetch;
-	baseURL: string;
-	collection: 'media' | 'gallery-images';
-	file: File;
-	payloadJson: Record<string, unknown>;
-}): Promise<{ ok: true; id: number } | { ok: false; message: string }> {
-	const formData = new FormData();
-	formData.append('file', args.file);
-	formData.append('_payload', JSON.stringify(args.payloadJson));
-
-	const res = await args.innerFetch(`${args.baseURL.replace(/\/$/, '')}/${args.collection}`, {
-		method: 'POST',
-		body: formData,
-		credentials: 'include'
-	});
-
-	let body: unknown;
-	try {
-		body = await res.json();
-	} catch {
-		return { ok: false, message: `HTTP ${res.status}` };
-	}
-
-	if (!res.ok) {
-		const errObj = body as { errors?: { message?: string }[]; message?: string };
-		const first = errObj.errors?.[0]?.message ?? errObj.message ?? `HTTP ${res.status}`;
-		return { ok: false, message: first };
-	}
-
-	const doc = body as { doc?: { id?: number } };
-	const id = doc.doc?.id;
-	if (typeof id !== 'number') {
-		return { ok: false, message: 'Unexpected response from CMS' };
-	}
-	return { ok: true, id };
-}
-
-function buildGalleryImagePayload(albumId: number, alt: string): Record<string, unknown> {
-	return {
-		alt,
-		settings: {
-			visibility: 'AUTHENTICATED',
-			isNsfw: false
-		},
-		albums: [albumId]
-	};
-}
-
-function buildMediaPayload(alt: string): Record<string, unknown> {
-	return { alt };
-}
-
-async function uploadForDestination(
-	innerFetch: typeof fetch,
-	baseURL: string,
-	dest: ShareTargetDestination,
-	file: File,
-	alt: string
-): Promise<{ ok: true; id: number } | { ok: false; message: string }> {
-	if (dest.mode === 'media') {
-		return payloadCreateUpload({
-			innerFetch,
-			baseURL,
-			collection: 'media',
-			file,
-			payloadJson: buildMediaPayload(alt)
-		});
-	}
-	return payloadCreateUpload({
-		innerFetch,
-		baseURL,
-		collection: 'gallery-images',
-		file,
-		payloadJson: buildGalleryImagePayload(dest.albumId, alt)
-	});
 }
 
 export const POST: RequestHandler = async ({ request, fetch, cookies, url: pageUrl }) => {
@@ -124,8 +30,6 @@ export const POST: RequestHandler = async ({ request, fetch, cookies, url: pageU
 			401
 		);
 	}
-
-	const dest = parseShareTargetDestination(cookies.get(SHARE_TARGET_DEST_COOKIE));
 
 	const formData = await request.formData();
 	const title = String(formData.get('title') ?? '').trim();
@@ -144,8 +48,8 @@ export const POST: RequestHandler = async ({ request, fetch, cookies, url: pageU
 		return shareResultHtml('No images received', 'The share did not include any image files.', 400);
 	}
 
-	const nonImages = files.filter((f) => !isImageFile(f));
-	if (nonImages.length > 0) {
+	const images = files.filter((f) => isImageFile(f));
+	if (images.length === 0) {
 		return shareResultHtml(
 			'Unsupported files',
 			'Only image types are accepted. Remove non-image items and try again.',
@@ -153,43 +57,51 @@ export const POST: RequestHandler = async ({ request, fetch, cookies, url: pageU
 		);
 	}
 
-	const { innerFetch, baseURL } = createPayloadInnerFetch(fetch, request);
+	const file = images[0];
+	const extraImagesDropped = Math.max(0, images.length - 1);
 
-	const uploadResults = await Promise.all(
-		files.map(async (file) => {
-			const alt = altFromShareContext(file, title, text, linkUrl);
-			const result = await uploadForDestination(innerFetch, baseURL, dest, file, alt);
-			return { file, result };
-		})
-	);
-
-	let ok = 0;
-	const errors: string[] = [];
-	for (const { file, result } of uploadResults) {
-		if (result.ok) {
-			ok += 1;
-		} else {
-			errors.push(`${file.name}: ${result.message}`);
-		}
+	const ab = await file.arrayBuffer();
+	const buffer = Buffer.from(ab);
+	if (buffer.byteLength > DRAFT_MAX_BYTES) {
+		return shareResultHtml(
+			'File too large',
+			'This image is larger than the allowed upload size.',
+			413
+		);
 	}
 
-	if (errors.length) {
-		const payload = JSON.stringify({ errors: errors.slice(0, 12) });
-		if (payload.length < 3500) {
-			cookies.set(SHARE_TARGET_FLASH_COOKIE, payload, {
-				path: '/',
-				maxAge: 120,
-				sameSite: 'lax',
-				httpOnly: true,
-				secure: !dev
-			});
+	let token: string;
+	try {
+		token = await saveDraft({
+			buffer,
+			meta: {
+				originalName: file.name || 'shared-image',
+				mimeType: file.type || 'application/octet-stream',
+				shareTitle: title,
+				shareText: text,
+				shareUrl: linkUrl,
+				extraImagesDropped
+			}
+		});
+	} catch (e) {
+		if (e instanceof Error && e.message === 'FILE_TOO_LARGE') {
+			return shareResultHtml(
+				'File too large',
+				'This image is larger than the allowed upload size.',
+				413
+			);
 		}
+		return shareResultHtml('Could not save upload', 'Try sharing again in a moment.', 500);
 	}
 
-	const sp = new URLSearchParams();
-	sp.set('uploaded', String(ok));
-	if (errors.length) sp.set('failed', String(errors.length));
+	cookies.set(SHARE_TARGET_DRAFT_COOKIE, token, {
+		path: '/',
+		maxAge: 15 * 60,
+		sameSite: 'lax',
+		httpOnly: true,
+		secure: !dev
+	});
 
-	const next = new URL(`/share-target?${sp.toString()}`, pageUrl);
+	const next = new URL('/share-target/review', pageUrl);
 	throw redirect(303, next.href);
 };

--- a/src/routes/api/share-target/draft/+server.ts
+++ b/src/routes/api/share-target/draft/+server.ts
@@ -1,0 +1,17 @@
+import { readDraftFile, SHARE_TARGET_DRAFT_COOKIE } from '$lib/share-target-draft.server';
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+/** Private preview of the pending share (requires draft cookie). */
+export const GET: RequestHandler = async ({ cookies }) => {
+	const token = cookies.get(SHARE_TARGET_DRAFT_COOKIE);
+	const draft = await readDraftFile(token);
+	if (!draft) {
+		throw error(404, 'Not found');
+	}
+	return new Response(new Uint8Array(draft.buffer), {
+		headers: {
+			'content-type': draft.meta.mimeType || 'application/octet-stream',
+			'cache-control': 'private, no-store'
+		}
+	});
+};

--- a/src/routes/manifest.json/+server.ts
+++ b/src/routes/manifest.json/+server.ts
@@ -1,28 +1,30 @@
-import { PUBLIC_URL } from '$env/static/public';
 import siteManifest from '$lib/site-manifest.json';
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 type SiteManifest = typeof siteManifest;
 
-function absoluteShareTargetAction(base: SiteManifest): SiteManifest {
+/**
+ * PR previews and alternate hosts must use THIS request's origin for
+ * `share_target.action` and `id`. Using `PUBLIC_URL` from the build breaks
+ * Android when the installed PWA origin does not match the action URL.
+ */
+function withInstallIdentity(base: SiteManifest, origin: string): SiteManifest & { id: string } {
 	const st = base.share_target;
-	if (!st?.action) return base;
-	if (st.action.startsWith('http://') || st.action.startsWith('https://')) return base;
-	const origin = PUBLIC_URL?.replace(/\/$/, '');
-	if (!origin) return base;
-	const path = st.action.startsWith('/') ? st.action : `/${st.action}`;
+	let share_target = st;
+	if (st?.action && !st.action.startsWith('http://') && !st.action.startsWith('https://')) {
+		const path = st.action.startsWith('/') ? st.action : `/${st.action}`;
+		share_target = { ...st, action: `${origin}${path}` };
+	}
 	return {
 		...base,
-		share_target: {
-			...st,
-			action: `${origin}${path}`
-		}
+		scope: '/',
+		id: `${origin}/`,
+		share_target
 	};
 }
 
-/** Serves the PWA manifest with an absolute `share_target.action` (helps Android registration). */
-export const GET: RequestHandler = () => {
-	const body = absoluteShareTargetAction(siteManifest);
+export const GET: RequestHandler = ({ url }) => {
+	const body = withInstallIdentity(siteManifest, url.origin);
 	return json(body, {
 		headers: {
 			'content-type': 'application/manifest+json; charset=utf-8',

--- a/src/routes/share-target/+page.server.ts
+++ b/src/routes/share-target/+page.server.ts
@@ -1,6 +1,7 @@
 import { PUBLIC_PAYLOAD_API_ENDPOINT } from '$env/static/public';
 import { createPayloadFetch } from '$lib/payload';
 import { getPayloadSDK } from '$lib/payload.server';
+import { readDraftMeta, SHARE_TARGET_DRAFT_COOKIE } from '$lib/share-target-draft.server';
 import {
 	parseShareTargetDestination,
 	SHARE_TARGET_DEST_COOKIE,
@@ -9,7 +10,7 @@ import {
 import type { GalleryAlbum } from '$lib/types/payload-types';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ cookies, fetch, request, url }) => {
+export const load: PageServerLoad = async ({ cookies, fetch, request }) => {
 	const sessionResponse = await fetch('/api/auth/get-session');
 	const session = sessionResponse.ok ? await sessionResponse.json() : null;
 
@@ -58,19 +59,13 @@ export const load: PageServerLoad = async ({ cookies, fetch, request, url }) => 
 		}
 	}
 
-	const uploadedRaw = url.searchParams.get('uploaded');
-	const failedRaw = url.searchParams.get('failed');
-	const uploaded = uploadedRaw != null ? Number.parseInt(uploadedRaw, 10) : null;
-	const failed = failedRaw != null ? Number.parseInt(failedRaw, 10) : null;
+	const hasDraft = Boolean(await readDraftMeta(cookies.get(SHARE_TARGET_DRAFT_COOKIE)));
 
 	return {
 		session,
 		destination,
 		albums,
 		flashErrors,
-		uploadSummary:
-			uploaded != null && Number.isFinite(uploaded)
-				? { uploaded, failed: failed != null && Number.isFinite(failed) ? failed : 0 }
-				: null
+		hasDraft
 	};
 };

--- a/src/routes/share-target/+page.svelte
+++ b/src/routes/share-target/+page.svelte
@@ -29,6 +29,9 @@
 			<strong>Chrome on Android</strong>. Safari-installed apps on iPhone and iPad do not appear in
 			the system share sheet yet. After changing the manifest, remove the home-screen app and add it
 			again so the OS picks up updates.
+			<strong>Preview deployments:</strong> the manifest must use the same host as the app you install;
+			if the share target vanished on a PR build, reinstall after deploy so Chrome picks up the fixed
+			manifest.
 		</p>
 
 		{#if data.hasDraft}

--- a/src/routes/share-target/+page.svelte
+++ b/src/routes/share-target/+page.svelte
@@ -8,7 +8,7 @@
 	const formKey = $derived(
 		`${data.destination.mode}-${
 			data.destination.mode === 'gallery-image' ? data.destination.albumId : 0
-		}-${data.uploadSummary?.uploaded ?? 'u'}-${data.uploadSummary?.failed ?? 'f'}-${data.flashErrors.length}`
+		}-${data.flashErrors.length}-${data.hasDraft ? 'd' : 'n'}`
 	);
 </script>
 
@@ -20,31 +20,28 @@
 	<Panel hasPadding={true} hasBorder={true}>
 		<h1>Share from your phone</h1>
 		<p class="lede">
-			When this site is installed as an app, you can share photos from your gallery into Payload.
-			Sign in on this device first, then pick where uploads go.
+			When this site is installed as an app, you can share a photo from your gallery. You will land
+			on a short form to set the title and choose Media or a gallery album before it uploads to
+			Payload. Sign in on this device first; you can also save a default destination below.
 		</p>
 		<p class="compat">
 			<strong>Device support:</strong> Web Share Target is supported for installed PWAs in
-			<strong>Chrome on Android</strong>. Safari-installed apps on iPhone and iPad do not appear in the
-			system share sheet yet. After changing the manifest, remove the home-screen app and add it again so
-			the OS picks up updates.
+			<strong>Chrome on Android</strong>. Safari-installed apps on iPhone and iPad do not appear in
+			the system share sheet yet. After changing the manifest, remove the home-screen app and add it
+			again so the OS picks up updates.
 		</p>
+
+		{#if data.hasDraft}
+			<p class="draft-banner" role="status">
+				<a href="/share-target/review">Finish a shared photo</a>
+				— an image is waiting on this device (expires in a few minutes).
+			</p>
+		{/if}
 
 		{#if !data.session?.user}
 			<p class="warn">
 				You are not signed in. <a href="/account/login">Sign in</a> before sharing images.
 			</p>
-		{/if}
-
-		{#if data.uploadSummary}
-			<div class="banner ok" role="status">
-				Uploaded {data.uploadSummary.uploaded} file{data.uploadSummary.uploaded === 1 ? '' : 's'} to Payload.
-				{#if data.uploadSummary.failed > 0}
-					<span class="partial">
-						{data.uploadSummary.failed} failed — see details below.
-					</span>
-				{/if}
-			</div>
 		{/if}
 
 		{#if data.flashErrors.length > 0}
@@ -97,6 +94,21 @@
 		color: var(--color-text-muted, #444);
 	}
 
+	.draft-banner {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		padding: 0.75rem 1rem;
+		border-radius: 4px;
+		margin: 0 0 1rem;
+		background: oklch(0.94 0.04 250);
+		border: 1px solid oklch(0.55 0.12 250);
+	}
+
+	.draft-banner a {
+		color: var(--color-primary);
+		font-weight: 600;
+	}
+
 	.warn {
 		font-family: var(--font-roboto);
 		font-size: var(--fs-s);
@@ -115,11 +127,6 @@
 		margin-bottom: 1rem;
 	}
 
-	.banner.ok {
-		background: oklch(0.94 0.03 145);
-		border: 1px solid oklch(0.55 0.12 145);
-	}
-
 	.banner.err {
 		background: oklch(0.95 0.04 25);
 		border: 1px solid var(--color-primary);
@@ -128,11 +135,5 @@
 	.banner ul {
 		margin: 0;
 		padding-left: 1.25rem;
-	}
-
-	.partial {
-		display: block;
-		margin-top: 0.35rem;
-		font-size: var(--fs-xs);
 	}
 </style>

--- a/src/routes/share-target/complete/+page.server.ts
+++ b/src/routes/share-target/complete/+page.server.ts
@@ -1,0 +1,52 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getPayloadSDK } from '$lib/payload.server';
+import { getMediaUrl } from '$lib/utils/media-url';
+import type { GalleryImage, Media } from '$lib/types/payload-types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url, fetch, request }) => {
+	const sessionResponse = await fetch('/api/auth/get-session');
+	const session = sessionResponse.ok ? await sessionResponse.json() : null;
+	if (!session?.user) {
+		throw redirect(303, '/share-target');
+	}
+
+	const kind = url.searchParams.get('kind');
+	const id = Number.parseInt(url.searchParams.get('id') ?? '', 10);
+	if (!Number.isFinite(id) || id <= 0) error(400, 'Invalid link');
+	if (kind !== 'media' && kind !== 'gallery-image') error(400, 'Invalid link');
+
+	const sdk = getPayloadSDK(fetch, request);
+	const collection = kind === 'media' ? 'media' : 'gallery-images';
+	const doc = (await sdk.findByID({
+		collection,
+		id,
+		depth: kind === 'gallery-image' ? 1 : 0,
+		disableErrors: true
+	})) as (Media | GalleryImage) | null;
+
+	if (!doc) error(404, 'Not found');
+
+	const sizes = doc.sizes as Record<string, { url?: string | null }> | undefined;
+	const path = sizes?.xlarge?.url ?? sizes?.large?.url ?? doc.url ?? sizes?.medium?.url ?? '';
+
+	const previewUrl = path ? getMediaUrl(path, true) : '';
+	const directFileUrl = path ? getMediaUrl(path, false) : '';
+
+	let galleryPageUrl: string | null = null;
+	if (kind === 'gallery-image' && 'albums' in doc && doc.albums?.[0]) {
+		const al0 = doc.albums[0];
+		if (typeof al0 === 'object' && al0 && 'slug' in al0 && typeof al0.slug === 'string') {
+			galleryPageUrl = `${url.origin}/galleries/${al0.slug}`;
+		}
+	}
+
+	return {
+		kind: kind as 'media' | 'gallery-image',
+		id,
+		alt: doc.alt,
+		previewUrl,
+		directFileUrl,
+		galleryPageUrl
+	};
+};

--- a/src/routes/share-target/complete/+page.svelte
+++ b/src/routes/share-target/complete/+page.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+	import Panel from '$lib/Panel.svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let copied = $state<string | null>(null);
+
+	async function copyText(text: string, key: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+			copied = key;
+			setTimeout(() => {
+				copied = null;
+			}, 2000);
+		} catch {
+			copied = 'error';
+			setTimeout(() => {
+				copied = null;
+			}, 2500);
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Uploaded | Share to site</title>
+</svelte:head>
+
+<div class="wrap">
+	<Panel hasPadding={true} hasBorder={true}>
+		<h1>Uploaded</h1>
+		<p class="lede">
+			{data.kind === 'media' ? 'Media' : 'Gallery image'} #{data.id} — {data.alt}
+		</p>
+
+		{#if data.previewUrl}
+			<div class="preview">
+				<img src={data.previewUrl} alt={data.alt} />
+			</div>
+		{/if}
+
+		<div class="links">
+			{#if data.directFileUrl}
+				<div class="row">
+					<label class="lbl" for="direct-url">Direct image URL</label>
+					<div class="copyrow">
+						<input id="direct-url" class="input" type="text" readonly value={data.directFileUrl} />
+						<button
+							type="button"
+							class="copybtn"
+							onclick={() => copyText(data.directFileUrl, 'direct')}
+						>
+							{copied === 'direct' ? 'Copied' : 'Copy'}
+						</button>
+					</div>
+				</div>
+			{/if}
+
+			{#if data.galleryPageUrl}
+				<div class="row">
+					<label class="lbl" for="gallery-url">Gallery page</label>
+					<div class="copyrow">
+						<input
+							id="gallery-url"
+							class="input"
+							type="text"
+							readonly
+							value={data.galleryPageUrl}
+						/>
+						<button
+							type="button"
+							class="copybtn"
+							onclick={() => copyText(data.galleryPageUrl!, 'gallery')}
+						>
+							{copied === 'gallery' ? 'Copied' : 'Copy'}
+						</button>
+					</div>
+					<a class="open" href={data.galleryPageUrl}>Open gallery</a>
+				</div>
+			{/if}
+		</div>
+
+		{#if copied === 'error'}
+			<p class="err" role="status">Clipboard was blocked — select the field and copy manually.</p>
+		{/if}
+
+		<p class="footer">
+			<a href="/share-target">Share again</a>
+			·
+			<a href="/">Home</a>
+		</p>
+	</Panel>
+</div>
+
+<style lang="postcss">
+	.wrap {
+		max-width: 42rem;
+		margin: 0 auto;
+		padding-block: 2rem;
+		padding-inline: 1rem;
+	}
+
+	h1 {
+		font-family: var(--font-permanent-marker);
+		font-size: var(--fs-l);
+		color: var(--color-primary);
+		margin: 0 0 0.75rem;
+	}
+
+	.lede {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		line-height: 1.5;
+		margin: 0 0 1.25rem;
+		color: var(--color-tertiary-darkest);
+	}
+
+	.preview {
+		border-radius: 6px;
+		overflow: hidden;
+		border: 2px solid var(--color-tertiary-lighter);
+		margin-bottom: 1.5rem;
+		max-height: 22rem;
+		background: var(--color-white-lightest);
+	}
+
+	.preview img {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-height: 22rem;
+		object-fit: contain;
+	}
+
+	.links {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.lbl {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		color: var(--color-tertiary-darker);
+	}
+
+	.copyrow {
+		display: flex;
+		gap: 0.5rem;
+		align-items: stretch;
+	}
+
+	.input {
+		flex: 1;
+		min-width: 0;
+		font-family: var(--font-source-code-pro);
+		font-size: var(--fs-xs);
+		padding: 0.5rem 0.65rem;
+		border: 2px solid var(--color-tertiary-lighter);
+		border-radius: 4px;
+		background: var(--color-white-lightest);
+		color: var(--color-tertiary-darkest);
+	}
+
+	.copybtn {
+		flex-shrink: 0;
+		padding: 0.5rem 0.85rem;
+		border: 2px solid var(--color-primary);
+		border-radius: 4px;
+		background: var(--color-primary);
+		color: var(--color-white-lightest);
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		cursor: pointer;
+	}
+
+	.open {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		color: var(--color-primary);
+	}
+
+	.err {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		color: var(--color-primary-darker);
+		margin: 1rem 0 0;
+	}
+
+	.footer {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		margin: 1.5rem 0 0;
+	}
+
+	.footer a {
+		color: var(--color-primary);
+	}
+</style>

--- a/src/routes/share-target/review/+page.server.ts
+++ b/src/routes/share-target/review/+page.server.ts
@@ -1,0 +1,156 @@
+import { PUBLIC_PAYLOAD_API_ENDPOINT } from '$env/static/public';
+import { createPayloadFetch, createPayloadInnerFetch } from '$lib/payload';
+import { getPayloadSDK } from '$lib/payload.server';
+import {
+	deleteDraft,
+	readDraftFile,
+	readDraftMeta,
+	SHARE_TARGET_DRAFT_COOKIE
+} from '$lib/share-target-draft.server';
+import { uploadForDestination } from '$lib/share-target-payload-upload.server';
+import {
+	parseShareTargetDestination,
+	SHARE_TARGET_DEST_COOKIE,
+	type ShareTargetDestination
+} from '$lib/share-target-destination';
+import type { GalleryAlbum } from '$lib/types/payload-types';
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+function suggestedAltFromDraft(draftMeta: {
+	shareTitle: string;
+	shareText: string;
+	shareUrl: string;
+	originalName: string;
+}): string {
+	const suggestedAlt =
+		[draftMeta.shareTitle, draftMeta.shareText, draftMeta.shareUrl]
+			.map((s) => s.trim())
+			.filter(Boolean)
+			.join(' — ') ||
+		draftMeta.originalName.replace(/\.[^.]+$/, '') ||
+		'Shared image';
+	return suggestedAlt.length > 500 ? suggestedAlt.slice(0, 497) + '…' : suggestedAlt;
+}
+
+export const load: PageServerLoad = async ({ cookies, fetch, request }) => {
+	const token = cookies.get(SHARE_TARGET_DRAFT_COOKIE);
+	const draftMeta = await readDraftMeta(token);
+	if (!draftMeta) {
+		throw redirect(303, '/share-target');
+	}
+
+	const suggestedAlt = suggestedAltFromDraft(draftMeta);
+
+	const sessionResponse = await fetch('/api/auth/get-session');
+	const session = sessionResponse.ok ? await sessionResponse.json() : null;
+
+	if (!session?.user) {
+		return {
+			session: null,
+			draft: draftMeta,
+			albums: [] as Pick<GalleryAlbum, 'id' | 'title' | 'slug'>[],
+			destination: { mode: 'media' } as ShareTargetDestination,
+			suggestedAlt
+		};
+	}
+
+	const payloadFetch = createPayloadFetch(fetch, request);
+	const meResponse = await payloadFetch(`${PUBLIC_PAYLOAD_API_ENDPOINT}/users/me`);
+	const payloadMe = meResponse.ok ? await meResponse.json() : null;
+	if (payloadMe?.user) {
+		session.user = { ...session.user, ...payloadMe.user };
+	}
+
+	let albums: Pick<GalleryAlbum, 'id' | 'title' | 'slug'>[] = [];
+	try {
+		const sdk = getPayloadSDK(fetch, request);
+		const res = await sdk.find({
+			collection: 'gallery-albums',
+			limit: 200,
+			depth: 0,
+			sort: 'title'
+		});
+		albums = res.docs.map((d) => ({
+			id: d.id,
+			title: d.title,
+			slug: d.slug ?? null
+		}));
+	} catch {
+		albums = [];
+	}
+
+	const destination = parseShareTargetDestination(cookies.get(SHARE_TARGET_DEST_COOKIE));
+
+	return {
+		session,
+		draft: draftMeta,
+		albums,
+		destination,
+		suggestedAlt
+	};
+};
+
+export const actions = {
+	upload: async ({ request, cookies, fetch }) => {
+		const sessionRes = await fetch('/api/auth/get-session');
+		const session = sessionRes.ok ? ((await sessionRes.json()) as { user?: unknown }) : null;
+		if (!session?.user) {
+			return fail(401, { error: 'Sign in to upload.' });
+		}
+
+		const token = cookies.get(SHARE_TARGET_DRAFT_COOKIE);
+		const draft = await readDraftFile(token);
+		if (!draft) {
+			cookies.delete(SHARE_TARGET_DRAFT_COOKIE, { path: '/' });
+			return fail(400, {
+				error:
+					'This upload draft expired or was already submitted. Share the photo again from your gallery.'
+			});
+		}
+
+		const fd = await request.formData();
+		const alt = String(fd.get('alt') ?? '').trim();
+		if (!alt) {
+			return fail(400, { error: 'Title / alt text is required.' });
+		}
+
+		const modeRaw = String(fd.get('destinationMode') ?? 'media');
+		const mode = modeRaw === 'gallery-image' ? 'gallery-image' : 'media';
+
+		let dest: ShareTargetDestination;
+		if (mode === 'gallery-image') {
+			const albumId = Number.parseInt(String(fd.get('albumId') ?? ''), 10);
+			if (!Number.isFinite(albumId) || albumId <= 0) {
+				return fail(400, { error: 'Choose an album for gallery uploads.' });
+			}
+			dest = { mode: 'gallery-image', albumId };
+		} else {
+			dest = { mode: 'media' };
+		}
+
+		const fileBody = new Blob([new Uint8Array(draft.buffer)], {
+			type: draft.meta.mimeType || 'application/octet-stream'
+		});
+
+		const { innerFetch, baseURL } = createPayloadInnerFetch(fetch, request);
+		const result = await uploadForDestination(
+			innerFetch,
+			baseURL,
+			dest,
+			fileBody,
+			draft.meta.originalName,
+			alt
+		);
+
+		if (!result.ok) {
+			return fail(400, { error: result.message });
+		}
+
+		await deleteDraft(token);
+		cookies.delete(SHARE_TARGET_DRAFT_COOKIE, { path: '/' });
+
+		const kind = dest.mode === 'media' ? 'media' : 'gallery-image';
+		throw redirect(303, `/share-target/complete?kind=${encodeURIComponent(kind)}&id=${result.id}`);
+	}
+} satisfies Actions;

--- a/src/routes/share-target/review/+page.svelte
+++ b/src/routes/share-target/review/+page.svelte
@@ -1,0 +1,325 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import Panel from '$lib/Panel.svelte';
+	import type { PageData, ActionData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let alt = $state('');
+	let mode = $state<'media' | 'gallery-image'>('media');
+	let albumId = $state('');
+	let submitting = $state(false);
+
+	const destSig = $derived(
+		`${data.destination.mode}-${data.destination.mode === 'gallery-image' ? data.destination.albumId : ''}-${data.suggestedAlt}`
+	);
+
+	let lastSynced = $state<string | null>(null);
+
+	$effect.pre(() => {
+		if (!data.draft || !data.session?.user) return;
+		if (lastSynced === destSig) return;
+		lastSynced = destSig;
+		alt = data.suggestedAlt;
+		mode = data.destination.mode === 'gallery-image' ? 'gallery-image' : 'media';
+		albumId = data.destination.mode === 'gallery-image' ? String(data.destination.albumId) : '';
+	});
+</script>
+
+<svelte:head>
+	<title>Finish upload | Share to site</title>
+</svelte:head>
+
+<div class="wrap">
+	<Panel hasPadding={true} hasBorder={true}>
+		{#if !data.session?.user}
+			<h1>Sign in to continue</h1>
+			<p class="lede">
+				You need an active session to finish this upload. Your shared image is held briefly on the
+				server.
+			</p>
+			<p class="actions">
+				<a class="btn" href="/account/login">Sign in</a>
+				<a class="btn secondary" href="/share-target">Back</a>
+			</p>
+		{:else if data.draft}
+			<h1>Finish upload</h1>
+			<p class="lede">Confirm the title and where this image should go, then upload to the CMS.</p>
+
+			{#if data.draft.extraImagesDropped > 0}
+				<p class="note">
+					Only the first image was kept ({data.draft.extraImagesDropped} other
+					{data.draft.extraImagesDropped === 1 ? 'image was' : 'images were'} skipped).
+				</p>
+			{/if}
+
+			{#if form?.error}
+				<p class="errbanner" role="alert">{form.error}</p>
+			{/if}
+
+			<div class="layout">
+				<div class="preview">
+					<img src="/api/share-target/draft" alt="Shared preview" width="320" height="320" />
+				</div>
+
+				<form
+					class="fields"
+					method="POST"
+					action="?/upload"
+					use:enhance={() => {
+						submitting = true;
+						return async ({ update }) => {
+							await update();
+							submitting = false;
+						};
+					}}
+				>
+					<label class="field">
+						<span>Title / alt text</span>
+						<input
+							class="input"
+							name="alt"
+							type="text"
+							maxlength="500"
+							required
+							bind:value={alt}
+							disabled={submitting}
+							autocomplete="off"
+						/>
+					</label>
+
+					<fieldset class="fieldset">
+						<legend>Destination</legend>
+						<label class="radio-line">
+							<input
+								type="radio"
+								name="destinationMode"
+								value="media"
+								bind:group={mode}
+								disabled={submitting}
+							/>
+							Media library
+						</label>
+						<label class="radio-line">
+							<input
+								type="radio"
+								name="destinationMode"
+								value="gallery-image"
+								bind:group={mode}
+								disabled={submitting}
+							/>
+							Gallery album
+						</label>
+					</fieldset>
+
+					{#if mode === 'gallery-image'}
+						{#if data.albums.length > 0}
+							<label class="field">
+								<span>Album</span>
+								<select
+									name="albumId"
+									class="select"
+									bind:value={albumId}
+									required={mode === 'gallery-image'}
+									disabled={submitting}
+								>
+									<option value="" disabled>Choose an album…</option>
+									{#each data.albums as a}
+										<option value={String(a.id)}>{a.title} (id {a.id})</option>
+									{/each}
+								</select>
+							</label>
+						{:else}
+							<label class="field">
+								<span>Album ID</span>
+								<input
+									class="input"
+									name="albumId"
+									type="number"
+									min="1"
+									step="1"
+									bind:value={albumId}
+									required={mode === 'gallery-image'}
+									disabled={submitting}
+								/>
+							</label>
+							<p class="hint">No albums were returned; enter a numeric album ID if you know one.</p>
+						{/if}
+					{/if}
+
+					<button type="submit" class="submit" disabled={submitting}>
+						{submitting ? 'Uploading…' : 'Upload to Payload'}
+					</button>
+				</form>
+			</div>
+		{/if}
+	</Panel>
+</div>
+
+<style lang="postcss">
+	.wrap {
+		max-width: 46rem;
+		margin: 0 auto;
+		padding-block: 2rem;
+		padding-inline: 1rem;
+	}
+
+	h1 {
+		font-family: var(--font-permanent-marker);
+		font-size: var(--fs-l);
+		color: var(--color-primary);
+		margin: 0 0 0.75rem;
+	}
+
+	.lede {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		line-height: 1.5;
+		margin: 0 0 1rem;
+		color: var(--color-tertiary-darkest);
+	}
+
+	.note {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		color: var(--color-tertiary);
+		margin: 0 0 1rem;
+	}
+
+	.errbanner {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		color: var(--color-primary-darker);
+		background: oklch(0.95 0.04 25);
+		border: 1px solid var(--color-primary);
+		padding: 0.65rem 1rem;
+		border-radius: 4px;
+		margin: 0 0 1rem;
+	}
+
+	.layout {
+		display: grid;
+		gap: 1.5rem;
+		align-items: start;
+	}
+
+	@media (min-width: 40rem) {
+		.layout {
+			grid-template-columns: minmax(0, 14rem) minmax(0, 1fr);
+		}
+	}
+
+	.preview {
+		border-radius: 6px;
+		overflow: hidden;
+		border: 2px solid var(--color-tertiary-lighter);
+		background: var(--color-white-lightest);
+	}
+
+	.preview img {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-height: 20rem;
+		object-fit: contain;
+	}
+
+	.fields {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		color: var(--color-tertiary-darker);
+	}
+
+	.fieldset {
+		border: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.fieldset legend {
+		font-family: var(--font-special-elite);
+		font-size: var(--fs-base);
+		color: var(--color-tertiary-darkest);
+		margin-bottom: 0.25rem;
+	}
+
+	.radio-line {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		cursor: pointer;
+	}
+
+	.input,
+	.select {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		padding: 0.5rem 0.65rem;
+		border: 2px solid var(--color-tertiary-lighter);
+		border-radius: 4px;
+		background: var(--color-white-lightest);
+		color: var(--color-tertiary-darkest);
+	}
+
+	.hint {
+		font-family: var(--font-roboto);
+		font-size: var(--fs-xs);
+		color: var(--color-tertiary);
+		margin: -0.5rem 0 0;
+	}
+
+	.submit {
+		margin-top: 0.25rem;
+		padding: 0.65rem 1.25rem;
+		border: 2px solid var(--color-primary);
+		border-radius: 4px;
+		background: var(--color-primary);
+		color: var(--color-white-lightest);
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		cursor: pointer;
+		align-self: flex-start;
+	}
+
+	.submit:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+
+	.actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.btn {
+		display: inline-block;
+		padding: 0.6rem 1.25rem;
+		border: 2px solid var(--color-primary);
+		border-radius: 4px;
+		background: var(--color-primary);
+		color: var(--color-white-lightest);
+		font-family: var(--font-roboto);
+		font-size: var(--fs-s);
+		text-decoration: none;
+	}
+
+	.btn.secondary {
+		background: transparent;
+		color: var(--color-primary);
+	}
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the Web Share Target flow: OS POST stages the image → **`/share-target/review`** form → server action → Payload → **`/share-target/complete`**.

## Deploy requirements

- **`BODY_SIZE_LIMIT`** (adapter-node, default **512K**): set to at least **`16M`** in production so large phone photos are not rejected before `POST /api/share-target` runs. Documented in **`.env.example`** and **`svelte.config.js`** comment.
- **`ORIGIN` / forwarded headers** as needed for adapter-node.
- Manifest uses **`url.origin`** for `share_target.action` / `id` (preview-safe).
- **`static/.well-known/assetlinks.json`** → `[]` (optional probe response).

## Verification

`npm run check`, `npm run lint`, `npm run test` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7914524-58f5-460c-bd79-5281e5c0cf9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7914524-58f5-460c-bd79-5281e5c0cf9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

