### PR TITLE
Show related model/article links and polish mobile UX.

### DIFF
--- a/src/lib/cache/articleCache.server.ts
+++ b/src/lib/cache/articleCache.server.ts
@@ -3,11 +3,13 @@ import {
 	ARTICLE_CACHE_TTL_S,
 	ARTICLE_STALE_THRESHOLD_S,
 	articleRedisKey,
-	type ArticlePageMeta
+	type ArticlePageMeta,
+	type ArticleRelatedModel
 } from '$lib/cache/articleCache';
 import { unwrapSwrCache, wrapForSwrCache } from '$lib/cache/payloadSwrCore';
 import { getPayloadSDK } from '$lib/payload/sdk.server';
 import type { Post } from '$lib/types/payload-types';
+import { toRelatedLinks } from '$lib/utils/relatedResources';
 
 type CachedArticle = {
 	data: Post;
@@ -16,6 +18,17 @@ type CachedArticle = {
 
 function isPublishedArticle(article: Post | null | undefined): article is Post {
 	return article?._status === 'published';
+}
+
+/** Cached articles may predate depth:1 fetches and only store related post IDs. */
+function needsRelatedPostPopulation(article: Post): boolean {
+	const posts = article.relatedPosts;
+	if (!posts?.length) return false;
+	return posts.some(
+		(p) =>
+			typeof p === 'number' ||
+			(typeof p === 'object' && p != null && (!p.title || !p.slug))
+	);
 }
 
 export function buildArticlePageMeta(doc: Post, origin: string, slug: string): ArticlePageMeta {
@@ -43,8 +56,33 @@ async function fetchArticleByIdFromCMS(articleId: number | string): Promise<Post
 	return sdk.findByID({
 		collection: 'posts',
 		id: articleId,
+		depth: 1,
 		disableErrors: true
 	});
+}
+
+/** Models that list this article under relatedResources.relatedPosts (CMS has no article→model field). */
+async function fetchModelsRelatedToArticle(
+	articleId: number | string
+): Promise<ArticleRelatedModel[]> {
+	const sdk = getPayloadSDK();
+	const result = await sdk.find({
+		collection: 'models',
+		limit: 50,
+		depth: 0,
+		select: {
+			id: true,
+			title: true,
+			slug: true
+		},
+		where: {
+			'relatedResources.relatedPosts': {
+				equals: articleId
+			}
+		}
+	});
+
+	return toRelatedLinks(result.docs);
 }
 
 async function resolvePublishedArticleId(slug: string): Promise<number | string | null> {
@@ -90,6 +128,7 @@ async function refreshArticleInBackground(
 export type ArticlePageDataResult = {
 	article: Post;
 	meta: ArticlePageMeta;
+	relatedModels: ArticleRelatedModel[];
 	cacheStatus: 'HIT' | 'MISS';
 };
 
@@ -106,7 +145,7 @@ export async function loadArticlePageData(
 	let doc: Post;
 	let cacheStatus: 'HIT' | 'MISS' = 'MISS';
 
-	if (cachedArticle) {
+	if (cachedArticle && !needsRelatedPostPopulation(cachedArticle.data)) {
 		doc = cachedArticle.data;
 		cacheStatus = 'HIT';
 		if (cachedArticle.isStale) {
@@ -119,9 +158,12 @@ export async function loadArticlePageData(
 		await cacheManager.set(redisKey, wrapForSwrCache(freshArticle), ARTICLE_CACHE_TTL_S);
 	}
 
+	const relatedModels = await fetchModelsRelatedToArticle(articleId);
+
 	return {
 		article: doc,
 		meta: buildArticlePageMeta(doc, origin, slug),
+		relatedModels,
 		cacheStatus
 	};
 }

--- a/src/lib/cache/articleCache.ts
+++ b/src/lib/cache/articleCache.ts
@@ -54,9 +54,17 @@ export type ArticlePageMeta = NonNullable<Post['meta']> & {
 	canonicalURL: string;
 };
 
+export type ArticleRelatedModel = {
+	id: number;
+	title: string;
+	slug: string;
+};
+
 export interface ArticleCacheData {
 	article: Post;
 	meta: ArticlePageMeta;
+	/** Models that list this article under relatedResources.relatedPosts */
+	relatedModels?: ArticleRelatedModel[];
 }
 
 export interface ArticlesListPagination {

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -394,45 +394,60 @@
 
 	dialog {
 		&.lightbox {
+			box-sizing: border-box;
+			position: fixed;
+			inset: 0;
 			border: 0;
-			width: 100%;
-			height: 100%;
+			width: 100vw;
+			height: 100dvh;
+			max-width: 100vw;
+			max-height: 100dvh;
 			padding: 0;
 			margin: 0;
-			max-width: 100vw;
-			max-height: 100vh;
+			overflow: hidden;
+			overscroll-behavior: contain;
 			background: rgba(0, 0, 0, 0.95);
-			position: relative;
 		}
 
 		.lightbox-contents {
+			box-sizing: border-box;
 			display: flex;
 			justify-content: center;
 			align-items: center;
 			width: 100%;
 			height: 100%;
+			min-height: 0;
 			padding: 5rem;
 			position: relative;
+			overflow: hidden;
 		}
 
 		.image-wrapper {
 			position: relative;
 			width: 100%;
 			height: 100%;
+			min-width: 0;
+			min-height: 0;
 			display: flex;
 			justify-content: center;
 			align-items: center;
+			overflow: hidden;
 		}
 
 		.lightbox-picture {
 			position: absolute;
-			display: block;
+			inset: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
 			max-width: 100%;
 			max-height: 100%;
 		}
 
 		.lightbox-image {
 			display: block;
+			width: auto;
+			height: auto;
 			max-width: 100%;
 			max-height: 100%;
 			object-fit: contain;
@@ -521,7 +536,7 @@
 
 	@media (max-width: 768px) {
 		.lightbox-contents {
-			padding: 3rem 1rem;
+			padding: 3.5rem 1rem 3rem;
 		}
 
 		.nav-button {

--- a/src/lib/components/ModelCard/ModelCard.svelte
+++ b/src/lib/components/ModelCard/ModelCard.svelte
@@ -185,7 +185,7 @@
 	.contents {
 		display: grid;
 		grid-template-columns: 1fr;
-		grid-template-rows: auto repeat(2, auto);
+		grid-template-rows: max-content max-content 1fr;
 		height: 100%;
 		min-width: 0;
 		background: var(--color-white-lighter);
@@ -201,14 +201,17 @@
 		font-size: 18px;
 		line-height: 1.2;
 		min-width: 0;
+		align-self: start;
 	}
 
 	.card-image {
 		position: relative;
 		min-width: 0;
+		align-self: start;
 
 		:global(.image-container) {
 			width: 100%;
+			border-block: 2px solid var(--color-primary-darker);
 		}
 
 		.status {

--- a/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
+++ b/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
@@ -3,16 +3,19 @@
 	import Image from '$lib/components/Image';
 	import Lexical from '$lib/components/Lexical';
 	import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
+	import type { ArticleRelatedModel } from '$lib/cache/articleCache';
 	import type { Media, Post, PostsTag } from '$lib/types/payload-types';
+	import { toRelatedLinks } from '$lib/utils/relatedResources';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
 		article: Post;
+		relatedModels?: ArticleRelatedModel[];
 		share?: Snippet;
 		footer?: Snippet;
 	}
 
-	let { article, share, footer }: Props = $props();
+	let { article, relatedModels = [], share, footer }: Props = $props();
 
 	const isAdmin = $derived(
 		!!page.data.session?.user &&
@@ -24,6 +27,9 @@
 			? `${PUBLIC_PAYLOAD_URL}/admin/collections/posts/${article.id}`
 			: null
 	);
+
+	const relatedPosts = $derived(toRelatedLinks(article.relatedPosts));
+	const hasRelatedResources = $derived(relatedPosts.length > 0 || relatedModels.length > 0);
 
 	function featuredMedia(post: Post): Media | null {
 		const fi = post.featuredImage;
@@ -149,6 +155,26 @@
 		>
 			<Lexical data={article.content as never} />
 		</div>
+
+		{#if hasRelatedResources}
+			<aside class="article-related" aria-label="Related links">
+				<h3 class="article-related-title">Related</h3>
+				<div class="article-related-cards">
+					{#each relatedPosts as post (post.id)}
+						<a href={`/articles/${post.slug}`} class="article-related-card">
+							<span class="article-related-card-meta">Article</span>
+							<span class="article-related-card-title">{post.title}</span>
+						</a>
+					{/each}
+					{#each relatedModels as model (model.id)}
+						<a href={`/models/${model.slug}`} class="article-related-card">
+							<span class="article-related-card-meta">Model</span>
+							<span class="article-related-card-title">{model.title}</span>
+						</a>
+					{/each}
+				</div>
+			</aside>
+		{/if}
 
 		{#if footer}
 			<div class="article-footer">
@@ -301,6 +327,61 @@
 
 	.article-lexical :global(a) {
 		color: #8b0000;
+	}
+
+	.article-related {
+		break-inside: avoid;
+		margin: 0 0 0.85rem;
+		font-family: 'Times New Roman', Times, serif;
+	}
+
+	.article-related-title {
+		margin: 0 0 0.55rem;
+		font-family: 'Times New Roman', Times, serif;
+		font-size: 1.17em;
+		font-weight: 700;
+		line-height: 1.25;
+		color: #1a1a1a;
+		break-after: avoid;
+	}
+
+	.article-related-cards {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+	}
+
+	.article-related-card {
+		display: block;
+		break-inside: avoid;
+		padding: 0.5rem 0.65rem;
+		border: 1px solid #ccc;
+		background: #e5e3db;
+		text-decoration: none;
+		color: #1a1a1a;
+
+		&:hover .article-related-card-title {
+			color: #8b0000;
+		}
+	}
+
+	.article-related-card-meta {
+		display: block;
+		margin-bottom: 0.12rem;
+		font-size: var(--fs-xs);
+		line-height: 1.35;
+		letter-spacing: 0.4px;
+		text-transform: uppercase;
+		color: #888;
+	}
+
+	.article-related-card-title {
+		display: block;
+		font-size: var(--fs-base);
+		font-weight: 700;
+		line-height: 1.3;
+		color: #1a1a1a;
+		transition: color 0.15s;
 	}
 
 	.article-footer {

--- a/src/lib/components/Newspaper/NewspaperLayout/NewspaperLayout.svelte
+++ b/src/lib/components/Newspaper/NewspaperLayout/NewspaperLayout.svelte
@@ -89,6 +89,16 @@
 		void goto(url, { keepFocus: true, noScroll: false });
 	}
 
+	function handleCategorySelect(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		handleCategoryClick(target.value || 'all');
+	}
+
+	function handleTagSelect(event: Event) {
+		const target = event.target as HTMLSelectElement;
+		handleTagClick(target.value || 'all');
+	}
+
 	function clearFilters() {
 		const url = new URL(page.url);
 		url.searchParams.delete('category');
@@ -168,46 +178,84 @@
 
 	{#if showFilters}
 		<div class="filter-bar" style:view-transition-name="newspaper-filters">
-			<div class="filter-bar-line filter-bar-line--sections">
-				<span class="filter-label">Sections:</span>
-				<button
-					type="button"
-					class="filter-link filter-link--section"
-					class:filter-link--active={!selectedCategory}
-					onclick={() => handleCategoryClick('all')}>All</button
-				>
-				{#each categories as category (category.id)}
+			<div class="filter-bar-selects">
+				<div class="filter-select-group">
+					<label class="filter-label" for="newspaper-section-select">Sections</label>
+					<select
+						id="newspaper-section-select"
+						class="filter-select"
+						value={selectedCategory || 'all'}
+						onchange={handleCategorySelect}
+					>
+						<option value="all">All</option>
+						{#each categories as category (category.id)}
+							<option value={category.slug ?? ''}>{category.title}</option>
+						{/each}
+					</select>
+				</div>
+				<div class="filter-select-group">
+					<label class="filter-label" for="newspaper-topic-select">Topics</label>
+					<select
+						id="newspaper-topic-select"
+						class="filter-select"
+						value={selectedTag || 'all'}
+						onchange={handleTagSelect}
+					>
+						<option value="all">All</option>
+						{#each tags as tag (tag.id)}
+							<option value={tag.slug ?? ''}>{tag.title}</option>
+						{/each}
+					</select>
+				</div>
+				{#if hasFilters}
+					<button type="button" class="filter-clear filter-clear--selects" onclick={clearFilters}
+						>[clear]</button
+					>
+				{/if}
+			</div>
+
+			<div class="filter-bar-links">
+				<div class="filter-bar-line filter-bar-line--sections">
+					<span class="filter-label">Sections:</span>
 					<button
 						type="button"
 						class="filter-link filter-link--section"
-						class:filter-link--active={selectedCategory === category.slug}
-						onclick={() => handleCategoryClick(category.slug)}
+						class:filter-link--active={!selectedCategory}
+						onclick={() => handleCategoryClick('all')}>All</button
 					>
-						{category.title}
-					</button>
-				{/each}
-			</div>
-			<div class="filter-bar-line filter-bar-line--topics">
-				<span class="filter-label">Topics:</span>
-				<button
-					type="button"
-					class="filter-link filter-link--tag"
-					class:filter-link--active={!selectedTag}
-					onclick={() => handleTagClick('all')}>All</button
-				>
-				{#each tags as tag (tag.id)}
+					{#each categories as category (category.id)}
+						<button
+							type="button"
+							class="filter-link filter-link--section"
+							class:filter-link--active={selectedCategory === category.slug}
+							onclick={() => handleCategoryClick(category.slug)}
+						>
+							{category.title}
+						</button>
+					{/each}
+				</div>
+				<div class="filter-bar-line filter-bar-line--topics">
+					<span class="filter-label">Topics:</span>
 					<button
 						type="button"
 						class="filter-link filter-link--tag"
-						class:filter-link--active={selectedTag === tag.slug}
-						onclick={() => handleTagClick(tag.slug)}
+						class:filter-link--active={!selectedTag}
+						onclick={() => handleTagClick('all')}>All</button
 					>
-						{tag.title}
-					</button>
-				{/each}
-				{#if hasFilters}
-					<button type="button" class="filter-clear" onclick={clearFilters}>[clear]</button>
-				{/if}
+					{#each tags as tag (tag.id)}
+						<button
+							type="button"
+							class="filter-link filter-link--tag"
+							class:filter-link--active={selectedTag === tag.slug}
+							onclick={() => handleTagClick(tag.slug)}
+						>
+							{tag.title}
+						</button>
+					{/each}
+					{#if hasFilters}
+						<button type="button" class="filter-clear" onclick={clearFilters}>[clear]</button>
+					{/if}
+				</div>
 			</div>
 		</div>
 	{/if}
@@ -368,6 +416,52 @@
 		border-bottom: 1px solid #ccc;
 	}
 
+	.filter-bar-selects {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		align-items: end;
+		gap: 0.55rem 0.65rem;
+	}
+
+	.filter-bar-links {
+		display: none;
+	}
+
+	.filter-select-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		min-width: 0;
+	}
+
+	.filter-select {
+		width: 100%;
+		min-width: 0;
+		padding: 0.35rem 1.6rem 0.35rem 0.45rem;
+		border: 1px solid #bbb;
+		border-radius: 0;
+		background-color: #fff;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-position: right 0.45rem center;
+		font-family: 'Times New Roman', Times, serif;
+		font-size: var(--fs-xs);
+		color: #333;
+		cursor: pointer;
+		appearance: none;
+
+		&:focus {
+			outline: 1px solid #8b0000;
+			outline-offset: 1px;
+		}
+	}
+
+	.filter-clear--selects {
+		grid-column: 1 / -1;
+		justify-self: start;
+		margin-left: 0;
+	}
+
 	.filter-bar-line {
 		display: flex;
 		align-items: baseline;
@@ -384,6 +478,10 @@
 		letter-spacing: 1px;
 		color: #333;
 		margin-right: 0.25rem;
+	}
+
+	.filter-select-group .filter-label {
+		margin-right: 0;
 	}
 
 	.filter-link {
@@ -439,6 +537,18 @@
 
 		&:hover {
 			color: #a00;
+		}
+	}
+
+	@media (min-width: 768px) {
+		.filter-bar-selects {
+			display: none;
+		}
+
+		.filter-bar-links {
+			display: flex;
+			flex-direction: column;
+			gap: 0.4rem;
 		}
 	}
 

--- a/src/lib/components/TopBar/TopBar.svelte
+++ b/src/lib/components/TopBar/TopBar.svelte
@@ -303,16 +303,21 @@
 		height: auto;
 		max-width: min(calc(100vw - 2rem), 26rem);
 		max-height: calc(100vh - 2rem);
+		overscroll-behavior: contain;
 	}
 
 	.menu-dialog::backdrop {
 		background: rgba(0, 0, 0, 0.65);
+		overscroll-behavior: none;
+		touch-action: none;
 	}
 
 	.menu-dialog__panel {
 		width: min(26rem, calc(100vw - 2rem));
 		max-height: calc(100vh - 2rem);
 		overflow-y: auto;
+		overscroll-behavior: contain;
+		touch-action: pan-y;
 		padding: 1.25rem 1.375rem;
 		background: var(--color-white) var(--linen-paper);
 		border: var(--border-width) solid var(--color-primary-darker);

--- a/src/lib/utils/relatedResources.ts
+++ b/src/lib/utils/relatedResources.ts
@@ -1,0 +1,24 @@
+export type RelatedResourceLink = {
+	id: number;
+	title: string;
+	slug: string;
+};
+
+type Relatable = {
+	id: number;
+	title?: string | null;
+	slug?: string | null;
+};
+
+/** Keep populated relationship docs that have a title + slug for linking. */
+export function toRelatedLinks(
+	items: (number | Relatable)[] | null | undefined
+): RelatedResourceLink[] {
+	const links: RelatedResourceLink[] = [];
+	for (const item of items ?? []) {
+		if (typeof item !== 'object' || item == null) continue;
+		if (!item.title || !item.slug) continue;
+		links.push({ id: item.id, title: item.title, slug: item.slug });
+	}
+	return links;
+}

--- a/src/routes/(site)/articles/[slug]/+page.svelte
+++ b/src/routes/(site)/articles/[slug]/+page.svelte
@@ -32,7 +32,7 @@
 		pagination={null}
 		showFilters={false}
 	>
-		<NewspaperArticleContent article={data.article}>
+		<NewspaperArticleContent article={data.article} relatedModels={data.relatedModels ?? []}>
 			{#snippet share()}
 				<ShareButtons url={page.url.href} title={data.article.title} />
 			{/snippet}

--- a/src/routes/(site)/articles/[slug]/+page.ts
+++ b/src/routes/(site)/articles/[slug]/+page.ts
@@ -31,13 +31,18 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 			if (!isFresh) {
 				scheduleBackgroundRefresh(idbKey, async () => {
 					const data = await fetchJson<ArticleCacheData>(`/api/articles/${slug}`, fetch);
-					await browserCache.set(idbKey, data);
+					await browserCache.set(idbKey, {
+						article: data.article,
+						meta: data.meta,
+						relatedModels: data.relatedModels ?? []
+					});
 				});
 			}
 
 			return {
 				article: entry.data.article,
 				meta: entry.data.meta,
+				relatedModels: entry.data.relatedModels ?? [],
 				_isFromCache: true,
 				_cacheIsFresh: isFresh
 			};
@@ -52,15 +57,19 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 	}
 
 	try {
-		const { article, meta } = await fetchJson<ArticleCacheData>(`/api/articles/${slug}`, fetch);
+		const { article, meta, relatedModels = [] } = await fetchJson<ArticleCacheData>(
+			`/api/articles/${slug}`,
+			fetch
+		);
 
 		if (browser) {
-			await browserCache.set(idbKey, { article, meta });
+			await browserCache.set(idbKey, { article, meta, relatedModels });
 		}
 
 		return {
 			article,
 			meta,
+			relatedModels,
 			_isFromCache: false,
 			_cacheIsFresh: true
 		};
@@ -71,6 +80,7 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 				return {
 					article: entry.data.article,
 					meta: entry.data.meta,
+					relatedModels: entry.data.relatedModels ?? [],
 					_isFromCache: true,
 					_cacheIsFresh: isCacheEntryFresh(entry.cachedAt, ARTICLE_STALE_THRESHOLD_S)
 				};

--- a/src/routes/(site)/models/+page.svelte
+++ b/src/routes/(site)/models/+page.svelte
@@ -25,11 +25,15 @@
 		page.url.searchParams.get('tag') || page.url.searchParams.get('tags') || ''
 	);
 	const selectedSort = $derived(normalizeModelSort(page.url.searchParams.get('sort')));
+	const perPageOptions = [6, 12, 15, 24, 48] as const;
+	const selectedLimit = $derived(Number(page.url.searchParams.get('limit')) || 15);
 
 	const hasActiveFilters = $derived(
 		Boolean(selectedManufacturer || selectedScale || selectedStatus || selectedTag) ||
 			selectedSort !== DEFAULT_MODEL_SORT
 	);
+
+	const totalModels = $derived(meta?.totalDocs ?? models.length);
 
 	const statusOptions = [
 		{ value: 'NOT_STARTED', label: 'Not started' },
@@ -69,92 +73,115 @@
 	}
 </script>
 
-<div class="filters font-oswald" aria-label="Model filters">
-	<div class="filter-group">
-		<label class="filter-label" for="model-manufacturer">Manufacturer</label>
-		<select
-			id="model-manufacturer"
-			class="filter-select"
-			value={selectedManufacturer}
-			onchange={(event) => handleSelectChange('manufacturer', event)}
-		>
-			<option value="">All</option>
-			{#each manufacturers as manufacturer (manufacturer.id)}
-				<option value={manufacturer.slug ?? ''}>{manufacturer.title}</option>
-			{/each}
-		</select>
-	</div>
+<section class="binder" aria-label="Model filters">
+	<div class="binder__spine" aria-hidden="true"></div>
 
-	<div class="filter-group">
-		<label class="filter-label" for="model-scale">Scale</label>
-		<select
-			id="model-scale"
-			class="filter-select"
-			value={selectedScale}
-			onchange={(event) => handleSelectChange('scale', event)}
-		>
-			<option value="">All</option>
-			{#each scales as scale (scale.id)}
-				<option value={scale.slug ?? ''}>{scale.title}</option>
-			{/each}
-		</select>
-	</div>
+	<div class="binder__sheet">
+		<div class="binder__top">
+			<p class="binder__mark">Set checklist</p>
+			<div class="binder__count" aria-live="polite">
+				<span class="binder__count-num">#{totalModels}</span>
+				<span class="binder__count-lbl">{totalModels === 1 ? 'card' : 'cards'}</span>
+			</div>
+		</div>
 
-	<div class="filter-group">
-		<label class="filter-label" for="model-status">Status</label>
-		<select
-			id="model-status"
-			class="filter-select"
-			value={selectedStatus}
-			onchange={(event) => handleSelectChange('status', event)}
-		>
-			<option value="">All</option>
-			{#each statusOptions as option (option.value)}
-				<option value={option.value}>{option.label}</option>
-			{/each}
-		</select>
-	</div>
+		<div class="binder__stats" role="group" aria-label="Filter fields">
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-manufacturer">Mfr</label>
+				<select
+					id="model-manufacturer"
+					class="stat-cell__select"
+					value={selectedManufacturer}
+					onchange={(event) => handleSelectChange('manufacturer', event)}
+				>
+					<option value="">Any</option>
+					{#each manufacturers as manufacturer (manufacturer.id)}
+						<option value={manufacturer.slug ?? ''}>{manufacturer.title}</option>
+					{/each}
+				</select>
+			</div>
 
-	<div class="filter-group">
-		<label class="filter-label" for="model-tag">Tag</label>
-		<select
-			id="model-tag"
-			class="filter-select"
-			value={selectedTag}
-			onchange={(event) => handleSelectChange('tag', event)}
-		>
-			<option value="">All</option>
-			{#each tags as tag (tag.id)}
-				<option value={tag.slug ?? ''}>{tag.title}</option>
-			{/each}
-		</select>
-	</div>
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-scale">Scale</label>
+				<select
+					id="model-scale"
+					class="stat-cell__select"
+					value={selectedScale}
+					onchange={(event) => handleSelectChange('scale', event)}
+				>
+					<option value="">Any</option>
+					{#each scales as scale (scale.id)}
+						<option value={scale.slug ?? ''}>{scale.title}</option>
+					{/each}
+				</select>
+			</div>
 
-	<div class="filter-group">
-		<label class="filter-label" for="model-sort">Sort</label>
-		<select
-			id="model-sort"
-			class="filter-select"
-			value={selectedSort}
-			onchange={(event) => handleSelectChange('sort', event)}
-		>
-			{#each MODEL_SORT_OPTIONS as option (option.value)}
-				<option value={option.value}>{option.label}</option>
-			{/each}
-		</select>
-	</div>
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-status">Status</label>
+				<select
+					id="model-status"
+					class="stat-cell__select"
+					value={selectedStatus}
+					onchange={(event) => handleSelectChange('status', event)}
+				>
+					<option value="">Any</option>
+					{#each statusOptions as option (option.value)}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</div>
 
-	{#if hasActiveFilters}
-		<button type="button" class="clear-btn" onclick={clearFilters}>Clear</button>
-	{/if}
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-tag">Tag</label>
+				<select
+					id="model-tag"
+					class="stat-cell__select"
+					value={selectedTag}
+					onchange={(event) => handleSelectChange('tag', event)}
+				>
+					<option value="">Any</option>
+					{#each tags as tag (tag.id)}
+						<option value={tag.slug ?? ''}>{tag.title}</option>
+					{/each}
+				</select>
+			</div>
 
-	<div class="result-count" aria-live="polite">
-		<span class="result-count-value">{meta?.totalDocs ?? models.length}</span>
-		<span class="result-count-label">
-			{(meta?.totalDocs ?? models.length) === 1 ? 'model' : 'models'}
-		</span>
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-sort">Sort</label>
+				<select
+					id="model-sort"
+					class="stat-cell__select"
+					value={selectedSort}
+					onchange={(event) => handleSelectChange('sort', event)}
+				>
+					{#each MODEL_SORT_OPTIONS as option (option.value)}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</div>
+
+			<div class="stat-cell">
+				<label class="stat-cell__label" for="model-limit">Per page</label>
+				<select
+					id="model-limit"
+					class="stat-cell__select"
+					value={selectedLimit}
+					onchange={(event) => handleSelectChange('limit', event)}
+				>
+					{#each perPageOptions as option (option)}
+						<option value={option}>{option}</option>
+					{/each}
+				</select>
+			</div>
+
+			{#if hasActiveFilters}
+				<div class="stat-cell stat-cell--action">
+					<button type="button" class="clear-chip" onclick={clearFilters}>Clear</button>
+				</div>
+			{/if}
+		</div>
 	</div>
-</div>
+</section>
 
 {#if models.length > 0}
 	<div class="grid">
@@ -168,86 +195,186 @@
 {/if}
 
 <style lang="postcss">
-	.filters {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		align-items: flex-end;
-		gap: 0.65rem 0.85rem;
+	.binder {
+		display: grid;
+		grid-template-columns: 0.55rem 1fr;
 		max-width: 68rem;
-		margin: 0 auto 1.5rem;
-		padding: 0.75rem 0.85rem;
-		border: 1px solid var(--color-tertiary-lighter);
-		background: var(--color-white-lightest);
+		margin: 0 auto 1.75rem;
+		background: var(--color-white-lighter);
+		border: 2px solid var(--color-primary-darker);
+		box-shadow: var(--box-shadow-elev-1);
 	}
 
-	.filter-group {
+	.binder__spine {
+		background: linear-gradient(
+			180deg,
+			var(--color-primary-darker),
+			var(--color-primary),
+			var(--color-primary-lighter)
+		);
+	}
+
+	.binder__sheet {
+		min-width: 0;
+		padding: 0.65rem 0.85rem 0.8rem;
+	}
+
+	.binder__top {
 		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 0.25rem;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding-bottom: 0.45rem;
+		margin-bottom: 0.55rem;
+		border-bottom: 2px solid var(--color-primary-darker);
 	}
 
-	.filter-label {
-		font-size: 0.8rem;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--color-tertiary);
-	}
-
-	.filter-select {
-		padding: 0.45rem 0.5rem;
-		font-size: 0.85rem;
-		border: 1px solid var(--color-tertiary-lighter);
-		background: var(--color-white-lightest);
-		color: var(--color-tertiary-darkest);
-		cursor: pointer;
-		min-width: 9.5rem;
-	}
-
-	.clear-btn {
-		align-self: stretch;
-		padding: 0.45rem 0.85rem;
+	.binder__mark {
+		margin: 0;
 		font-family: var(--font-oswald);
-		font-size: 0.8rem;
+		font-size: 0.78rem;
+		font-weight: 600;
+		letter-spacing: 0.16em;
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		border: 1px solid var(--color-tertiary-lighter);
-		background: transparent;
-		color: var(--color-tertiary-darker);
-		cursor: pointer;
-
-		&:hover {
-			border-color: var(--color-primary);
-			color: var(--color-primary-darker);
-		}
+		text-indent: 0;
+		color: var(--color-primary-darker);
 	}
 
-	.result-count {
+	.binder__count {
 		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-self: stretch;
-		min-width: 5.5rem;
-		padding: 0.45rem 0.75rem;
-		text-align: center;
+		align-items: baseline;
+		gap: 0.35rem;
+		font-family: var(--font-oswald);
 		color: var(--color-tertiary-darker);
-		border: 1px solid var(--color-tertiary-lighter);
-		background: rgb(255 255 255 / 0.72);
 	}
 
-	.result-count-value {
+	.binder__count-num {
 		font-family: var(--font-special-elite);
-		font-size: clamp(1.15rem, 2vw, 1.4rem);
+		font-size: 1.15rem;
 		line-height: 1;
 		color: var(--color-primary-darker);
 	}
 
-	.result-count-label {
-		margin-top: 0.2rem;
-		font-size: 0.72rem;
+	.binder__count-lbl {
+		font-size: 0.7rem;
+		letter-spacing: 0.08em;
 		text-transform: uppercase;
-		letter-spacing: 0.06em;
+		color: var(--color-tertiary);
+	}
+
+	.binder__stats {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.75rem 0.65rem;
+	}
+
+	.stat-cell {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		min-width: 0;
+		padding-bottom: 0.15rem;
+		border-bottom: 1px dotted var(--color-tertiary-darker);
+	}
+
+	.stat-cell--action {
+		grid-column: 1 / -1;
+		align-items: center;
+		justify-content: center;
+		border-bottom: none;
+		padding-bottom: 0;
+	}
+
+	.stat-cell__label {
+		font-family: var(--font-oswald);
+		font-size: 0.68rem;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--color-tertiary);
+	}
+
+	.stat-cell__select {
+		width: 100%;
+		min-width: 0;
+		margin: 0;
+		padding: 0.15rem 1.4rem 0.2rem 0;
+		border: none;
+		border-radius: 0;
+		background-color: transparent;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-position: right 0.1rem center;
+		font-family: var(--font-oswald);
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: var(--color-primary-darkest);
+		cursor: pointer;
+		appearance: none;
+
+		&:focus {
+			outline: none;
+			color: var(--color-primary);
+		}
+	}
+
+	.clear-chip {
+		padding: 0.3rem 0.85rem;
+		border: none;
+		background: var(--color-tertiary-lighter);
+		color: var(--color-white-lighter);
+		font-family: var(--font-oswald);
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		cursor: pointer;
+		transform: skew(-10deg);
+
+		&:hover {
+			background: var(--color-primary);
+		}
+	}
+
+	@media screen and (min-width: 900px) {
+		.binder {
+			grid-template-columns: 0.7rem 1fr;
+		}
+
+		.binder__sheet {
+			padding: 0.7rem 1.1rem 0.85rem;
+		}
+
+		.binder__stats {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: stretch;
+			gap: 0.75rem 0;
+		}
+
+		.stat-cell {
+			flex: 1 1 0;
+			padding: 0 0.85rem;
+			border-bottom: none;
+			border-right: 1px dotted var(--color-tertiary-darker);
+		}
+
+		.stat-cell:first-child {
+			padding-left: 0;
+		}
+
+		.stat-cell--action {
+			flex: 0 0 auto;
+			padding-right: 0;
+			border-right: none;
+			justify-content: flex-end;
+			align-items: flex-end;
+		}
+
+		.stat-cell:last-child {
+			border-right: none;
+			padding-right: 0;
+		}
 	}
 
 	.grid {

--- a/src/routes/(site)/models/[slug]/+page.server.ts
+++ b/src/routes/(site)/models/[slug]/+page.server.ts
@@ -5,6 +5,7 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ fetch, request, params, url }) => {
 	const modelData = await getPayloadSDK(fetch, request).find({
 		collection: 'models',
+		depth: 1,
 		where: {
 			slug: {
 				equals: params.slug
@@ -20,7 +21,8 @@ export const load: PageServerLoad = async ({ fetch, request, params, url }) => {
 			clockify_project: true,
 			buildLog: true,
 			image: true,
-			meta: true
+			meta: true,
+			relatedResources: true
 		}
 	});
 

--- a/src/routes/(site)/models/[slug]/+page.svelte
+++ b/src/routes/(site)/models/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
 	import Image from '$lib/components/Image';
 	import Icon from '$lib/components/Icon';
 	import Panel from '$lib/components/Panel';
@@ -8,6 +9,7 @@
 	import { type Kit, type Media } from '$lib/types/payload-types.js';
 	import { convertDate } from '$lib/utils/convertDate';
 	import { makeClockifyDurationFriendly } from '$lib/utils/makeClockifyDurationFriendly';
+	import { toRelatedLinks } from '$lib/utils/relatedResources';
 	import Disqus from '$lib/components/Disqus';
 	import ShareButtons from '$lib/components/ShareButtons';
 	import VideoPlayer from '$lib/components/VideoPlayer';
@@ -36,6 +38,18 @@
 	const clockifyDuration = $derived(
 		clockifyProject ? makeClockifyDurationFriendly(clockifyProject.duration, false, true) : null
 	);
+	const isAdmin = $derived(
+		!!page.data.session?.user &&
+			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
+	);
+	const cmsEditHref = $derived(
+		isAdmin && model.id != null
+			? `${PUBLIC_PAYLOAD_URL}/admin/collections/models/${model.id}`
+			: null
+	);
+	const relatedPosts = $derived(toRelatedLinks(model.relatedResources?.relatedPosts));
+	const relatedModels = $derived(toRelatedLinks(model.relatedResources?.relatedModels));
+	const hasRelatedResources = $derived(relatedPosts.length > 0 || relatedModels.length > 0);
 
 	$effect(() => {
 		async function getClockifyProject() {
@@ -75,6 +89,17 @@
 								<Icon name="clock" size={18} />
 								<span>{clockifyDuration}</span>
 							</span>
+						{/if}
+						{#if cmsEditHref}
+							<a
+								href={cmsEditHref}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="cms-edit-link"
+								aria-label="Edit this model in the CMS (opens in a new tab)"
+							>
+								Edit in CMS
+							</a>
 						{/if}
 					</div>
 					<div class="hero-share-wrapper">
@@ -140,6 +165,30 @@
 						</div>
 					{/if}
 				</StickyNote>
+
+				{#if hasRelatedResources}
+					<section class="related-section" aria-labelledby="model-related-heading">
+						<h2 id="model-related-heading" class="related-heading">Related</h2>
+						<ul class="related-list">
+							{#each relatedPosts as post (post.id)}
+								<li>
+									<a href={`/articles/${post.slug}`} class="related-link">
+										<span class="related-link-title">{post.title}</span>
+										<span class="related-link-meta">Article</span>
+									</a>
+								</li>
+							{/each}
+							{#each relatedModels as related (related.id)}
+								<li>
+									<a href={`/models/${related.slug}`} class="related-link">
+										<span class="related-link-title">{related.title}</span>
+										<span class="related-link-meta">Model</span>
+									</a>
+								</li>
+							{/each}
+						</ul>
+					</section>
+				{/if}
 
 				<!-- Videos -->
 				{#if model.model_meta?.videos && model.model_meta.videos.length > 0}
@@ -265,6 +314,20 @@
 		color: var(--color-primary-darker);
 	}
 
+	.cms-edit-link {
+		font-family: var(--font-oswald);
+		font-size: var(--fs-xs);
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		text-decoration: underline;
+		color: var(--color-primary-darker);
+
+		&:hover {
+			color: var(--color-secondary);
+		}
+	}
+
 	.hero-share-wrapper :global(.hero-share) {
 		margin: 0;
 	}
@@ -288,6 +351,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 2rem;
+		min-height: 100%;
 	}
 
 	.sidebar-column {
@@ -301,7 +365,70 @@
 		align-self: center;
 	}
 
+	.related-section {
+		border: var(--border-width) solid var(--color-primary-darker);
+		background: var(--linen-paper);
+		padding: 1rem;
+	}
+
+	.related-heading {
+		margin: 0 0 0.75rem;
+		font-family: var(--font-oswald);
+		font-size: var(--fs-base);
+		color: var(--color-primary-darker);
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+	}
+
+	.related-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.related-link {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+		padding: 0.45rem 0;
+		border-bottom: 1px dotted color-mix(in srgb, var(--color-primary-darker) 30%, transparent);
+		text-decoration: none;
+		color: inherit;
+
+		&:first-child {
+			padding-top: 0;
+		}
+
+		&:last-child {
+			border-bottom: none;
+			padding-bottom: 0;
+		}
+
+		&:hover .related-link-title {
+			color: var(--color-secondary);
+		}
+	}
+
+	.related-link-title {
+		font-family: var(--font-oswald);
+		font-size: var(--fs-base);
+		line-height: 1.25;
+		color: var(--color-primary-darker);
+		transition: color 0.2s;
+	}
+
+	.related-link-meta {
+		font-family: var(--font-oswald);
+		font-size: var(--fs-xs);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--color-tertiary);
+	}
+
 	.build-log-wrapper {
+		flex: 1;
 		background: linear-gradient(135deg, #c9b287 0%, #b39d6f 100%);
 		border: var(--border-width) solid #7a6a4a;
 		padding: clamp(1rem, 1rem + 1vw, 2rem);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -26,6 +26,17 @@
 		min-height: 100dvh;
 	}
 
+	/* Block background scroll while any modal <dialog> is open (showModal). */
+	html:has(dialog:modal) {
+		overflow: hidden;
+		overscroll-behavior: none;
+	}
+
+	body:has(dialog:modal) {
+		overflow: hidden;
+		overscroll-behavior: none;
+	}
+
 	@media (prefers-color-scheme: dark) {
 		body {
 			/* Solid fill; animated grunge is GrungeOverlay (WebGL) in the site layout */


### PR DESCRIPTION
Surface CMS related resources on model and article pages, stretch the build log beside the sidebar, and tighten lightbox, menu scroll lock, and listing filters for smaller screens.