### PR TITLE
Fix outdated pnpm lockfile after Redis removal

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@tanstack/svelte-query-persist-client':
         specifier: ^6.1.38
         version: 6.1.38(@tanstack/svelte-query@6.1.38(svelte@5.46.1))(svelte@5.46.1)
-      '@upstash/redis':
-        specifier: ^1.36.0
-        version: 1.36.0
       better-auth:
         specifier: ^1.4.19
         version: 1.4.19(@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@22.15.17)(lightningcss@1.30.1)(tsx@4.21.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@22.15.17)(lightningcss@1.30.1)(tsx@4.21.0)))(react-dom@19.2.4(react@19.2.3))(react@19.2.3)(svelte@5.46.1)(vitest@4.1.2)
@@ -1397,9 +1394,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.51.0':
     resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@upstash/redis@1.36.0':
-    resolution: {integrity: sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==}
 
   '@videojs/http-streaming@3.17.2':
     resolution: {integrity: sha512-VBQ3W4wnKnVKb/limLdtSD2rAd5cmHN70xoMf4OmuDd0t2kfJX04G+sfw6u2j8oOm2BXYM9E1f4acHruqKnM1g==}
@@ -3243,9 +3237,6 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
-  uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -4606,10 +4597,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
-
-  '@upstash/redis@1.36.0':
-    dependencies:
-      uncrypto: 0.1.3
 
   '@videojs/http-streaming@3.17.2(video.js@8.23.4)':
     dependencies:
@@ -6495,8 +6482,6 @@ snapshots:
   typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
-
-  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary
- Regenerates `pnpm-lock.yaml` so it no longer lists `@upstash/redis` under importers after that dependency was removed from `package.json`.
- Unblocks Coolify deploys and any CI that runs `pnpm install` with frozen-lockfile.

## Root cause
PR #90 removed `@upstash/redis` from `package.json` but the lockfile importers section still referenced it, causing:

`ERR_PNPM_OUTDATED_LOCKFILE ... Failure reason: ... @upstash/redis@^1.36.0`

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [ ] Coolify redeploy of `main` after merge succeeds past the install step

Made with [Cursor](https://cursor.com)