### PR TITLE
Cut shared chrome cost across every (site) page

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@200..700&family=Permanent+Marker&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Special+Elite&family=Delius&display=swap"
+			href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@300;400;500;600;700&family=Permanent+Marker&family=Roboto:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,700&family=Source+Code+Pro:wght@400;500;600;700&family=Special+Elite&family=Delius&display=swap"
 			rel="preload"
 			as="style"
 			onload="
@@ -19,7 +19,7 @@
 		/>
 		<noscript>
 			<link
-				href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@200..700&family=Permanent+Marker&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Special+Elite&family=Delius&display=swap"
+				href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@300;400;500;600;700&family=Permanent+Marker&family=Roboto:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,700&family=Source+Code+Pro:wght@400;500;600;700&family=Special+Elite&family=Delius&display=swap"
 				rel="stylesheet"
 			/>
 		</noscript>

--- a/src/lib/auth/hasBetterAuthCookie.ts
+++ b/src/lib/auth/hasBetterAuthCookie.ts
@@ -1,0 +1,5 @@
+/** True when the request likely has a Better Auth session cookie. */
+export function hasBetterAuthCookie(cookie: string | null | undefined): boolean {
+	if (!cookie) return false;
+	return /(?:^|;\s*)(?:__Secure-)?better-auth\./.test(cookie);
+}

--- a/src/lib/auth/loadSession.server.ts
+++ b/src/lib/auth/loadSession.server.ts
@@ -1,4 +1,5 @@
 import { extractPayloadMeUser, mergeSessionUser } from '$lib/auth/mergePayloadUser';
+import { hasBetterAuthCookie } from '$lib/auth/hasBetterAuthCookie';
 import { getPayloadApiBaseUrl } from '$lib/payload/api-base-url.server';
 import { createPayloadFetch } from '$lib/payload';
 
@@ -16,15 +17,31 @@ export async function loadSession(
 	const sessionInit: RequestInit | undefined = cookie ? { headers: { cookie } } : undefined;
 
 	try {
-		const sessionResponse = await fetch('/api/auth/get-session', sessionInit);
+		const payloadFetch = createPayloadFetch(fetch, request);
+		// When a better-auth cookie is present, fetch session + /users/me together
+		// to cut the SSR waterfall on every document load.
+		const mePromise = hasBetterAuthCookie(cookie)
+			? payloadFetch(`${getPayloadApiBaseUrl()}/users/me`).catch(() => null)
+			: Promise.resolve(null);
+
+		const [sessionResponse, meResponse] = await Promise.all([
+			fetch('/api/auth/get-session', sessionInit),
+			mePromise
+		]);
 		const session = sessionResponse.ok ? await sessionResponse.json() : null;
 
-		if (session?.user) {
+		if (session?.user && meResponse?.ok) {
 			try {
-				const payloadFetch = createPayloadFetch(fetch, request);
-				const meResponse = await payloadFetch(`${getPayloadApiBaseUrl()}/users/me`);
-				if (meResponse.ok) {
-					const payloadMe = await meResponse.json();
+				const payloadMe = await meResponse.json();
+				session.user = mergeSessionUser(session.user, extractPayloadMeUser(payloadMe));
+			} catch {
+				// Payload body unreadable — keep the base session.
+			}
+		} else if (session?.user && !meResponse) {
+			try {
+				const fallback = await payloadFetch(`${getPayloadApiBaseUrl()}/users/me`);
+				if (fallback.ok) {
+					const payloadMe = await fallback.json();
 					session.user = mergeSessionUser(session.user, extractPayloadMeUser(payloadMe));
 				}
 			} catch {

--- a/src/lib/auth/loadSession.ts
+++ b/src/lib/auth/loadSession.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { isBrowserOnline } from '$lib/utils/online';
+import { hasBetterAuthCookie } from '$lib/auth/hasBetterAuthCookie';
 import { extractPayloadMeUser, mergeSessionUser } from '$lib/auth/mergePayloadUser';
 
 export type SessionShape = {
@@ -20,21 +21,36 @@ export async function loadSession(
 		return null;
 	}
 
-	const cookie = request?.headers.get('cookie');
-	const sessionInit: RequestInit | undefined = cookie ? { headers: { cookie } } : undefined;
+	// Prefer the Request cookie jar (includes HttpOnly). document.cookie cannot.
+	const cookie = request?.headers.get('cookie') ?? null;
+	const sessionInit: RequestInit = cookie
+		? { headers: { cookie }, credentials: 'include' }
+		: { credentials: 'include' };
 
 	try {
-		const sessionResponse = await fetch('/api/auth/get-session', sessionInit);
+		const meInit: RequestInit = { ...sessionInit, credentials: 'include' };
+		const mePromise = hasBetterAuthCookie(cookie)
+			? fetch('/api/users/me', meInit).catch(() => null)
+			: Promise.resolve(null);
+
+		const [sessionResponse, meResponse] = await Promise.all([
+			fetch('/api/auth/get-session', sessionInit),
+			mePromise
+		]);
 		const session = sessionResponse.ok ? await sessionResponse.json() : null;
 
-		if (session?.user) {
+		if (session?.user && meResponse?.ok) {
 			try {
-				const meResponse = await fetch('/api/users/me', {
-					...sessionInit,
-					credentials: 'include'
-				});
-				if (meResponse.ok) {
-					const payloadMe = await meResponse.json();
+				const payloadMe = await meResponse.json();
+				session.user = mergeSessionUser(session.user, extractPayloadMeUser(payloadMe));
+			} catch {
+				// Payload body unreadable — keep the base session.
+			}
+		} else if (session?.user && !meResponse) {
+			try {
+				const fallback = await fetch('/api/users/me', meInit);
+				if (fallback.ok) {
+					const payloadMe = await fallback.json();
 					session.user = mergeSessionUser(session.user, extractPayloadMeUser(payloadMe));
 				}
 			} catch {

--- a/src/lib/auth/requireAdmin.server.ts
+++ b/src/lib/auth/requireAdmin.server.ts
@@ -1,4 +1,5 @@
 import { extractPayloadMeUser, mergeSessionUser } from '$lib/auth/mergePayloadUser';
+import { hasBetterAuthCookie } from '$lib/auth/hasBetterAuthCookie';
 import { getPayloadApiBaseUrl } from '$lib/payload/api-base-url.server';
 import { createPayloadFetch } from '$lib/payload';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -8,16 +9,28 @@ import type { RequestEvent } from '@sveltejs/kit';
  * so `role` (e.g. admin) is present when the user is logged in.
  */
 export async function getMergedSessionUser(event: RequestEvent) {
-	const sessionRes = await event.fetch(`${event.url.origin}/api/auth/get-session`, {
-		headers: { cookie: event.request.headers.get('cookie') ?? '' }
-	});
+	const cookie = event.request.headers.get('cookie') ?? '';
+	const payloadFetch = createPayloadFetch(event.fetch, event.request);
+
+	const mePromise = hasBetterAuthCookie(cookie)
+		? payloadFetch(`${getPayloadApiBaseUrl()}/users/me`).catch(() => null)
+		: Promise.resolve(null);
+
+	const [sessionRes, meRes] = await Promise.all([
+		event.fetch(`${event.url.origin}/api/auth/get-session`, {
+			headers: { cookie }
+		}),
+		mePromise
+	]);
 	if (!sessionRes.ok) return null;
 	const session = await sessionRes.json();
 	if (!session?.user) return null;
 
-	const payloadFetch = createPayloadFetch(event.fetch, event.request);
-	const meRes = await payloadFetch(`${getPayloadApiBaseUrl()}/users/me`);
-	const payloadMe = meRes.ok ? await meRes.json() : null;
+	let payloadMe = meRes?.ok ? await meRes.json() : null;
+	if (!payloadMe) {
+		const fallback = await payloadFetch(`${getPayloadApiBaseUrl()}/users/me`);
+		payloadMe = fallback.ok ? await fallback.json() : null;
+	}
 	return mergeSessionUser(session.user, extractPayloadMeUser(payloadMe));
 }
 

--- a/src/lib/components/AdminUtilitiesDock/AdminUtilitiesDockLazy.svelte
+++ b/src/lib/components/AdminUtilitiesDock/AdminUtilitiesDockLazy.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	/**
+	 * Lazy-loads the admin utilities dock (and highlight.js) only for admins
+	 * so public visitors do not pay for that JS on the critical path.
+	 */
+	import { page } from '$app/state';
+	import type { Component } from 'svelte';
+
+	let Dock = $state<Component | null>(null);
+
+	const isAdmin = $derived(
+		!!page.data.session?.user &&
+			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
+	);
+
+	$effect(() => {
+		if (!isAdmin || Dock) return;
+		let cancelled = false;
+		void import('$lib/components/AdminUtilitiesDock/AdminUtilitiesDock.svelte').then((mod) => {
+			if (!cancelled) Dock = mod.default;
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
+</script>
+
+{#if isAdmin && Dock}
+	<Dock />
+{/if}

--- a/src/lib/components/GrungeOverlay/GrungeOverlay.svelte
+++ b/src/lib/components/GrungeOverlay/GrungeOverlay.svelte
@@ -161,247 +161,279 @@
 	}
 
 	onMount(() => {
+		let cancelled = false;
 		let offMql: (() => void) | undefined;
+		let idleId: number | undefined;
+		let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
+		let disposeGl: (() => void) | undefined;
+
 		if (modeProp === undefined) {
 			mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 		} else {
 			mode = modeProp;
 		}
 
-		/** Narrow viewports + touch / coarse pointer: throttle cost (shader is fill-rate heavy). */
-		const mqPerf = window.matchMedia('(max-width: 768px), (pointer: coarse)');
+		/** `?grungePerf=high` restores uncapped desktop cost for local QA only. */
+		const highPerf =
+			import.meta.env.DEV &&
+			(window.location.search.includes('grungePerf=high') ||
+				window.location.search.includes('grungePerf=desktop'));
 
-		/** `?grungePerf=mobile` | `low` or `desktop` | `high` — preview tier on any device (local QA). */
-		const perfOverride = ((): 'mobile' | 'desktop' | null => {
-			const q = new URLSearchParams(window.location.search).get('grungePerf');
-			if (q === 'mobile' || q === 'low') return 'mobile';
-			if (q === 'desktop' || q === 'high') return 'desktop';
-			return null;
-		})();
-		function perfTierActive(): boolean {
-			if (perfOverride === 'mobile') return true;
-			if (perfOverride === 'desktop') return false;
-			return mqPerf.matches;
-		}
-		if (perfOverride !== null && import.meta.env.DEV) {
-			console.info(
-				`[GrungeOverlay] grungePerf=${perfOverride} — canvas uses ${perfTierActive() ? 'mobile (lower DPR, ~30fps cap)' : 'desktop'} tier`
-			);
+		function scheduleAfterPaint(task: () => void) {
+			const run = () => {
+				if (cancelled) return;
+				task();
+			};
+			const ric = (
+				window as Window & {
+					requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+				}
+			).requestIdleCallback;
+			if (typeof ric === 'function') {
+				idleId = ric(run, { timeout: 2000 });
+				return;
+			}
+			// Fallback: wait two frames so first paint / LCP can settle first.
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					idleTimeoutId = setTimeout(run, 0);
+				});
+			});
 		}
 
-		const gl = (canvas.getContext('webgl', {
-			alpha: true,
-			premultipliedAlpha: false,
-			powerPreference: perfTierActive() ? 'low-power' : 'default'
-		}) ??
-			canvas.getContext('experimental-webgl', {
+		function startWebGl() {
+			if (cancelled || !canvas || !host) return;
+
+			const gl = (canvas.getContext('webgl', {
 				alpha: true,
 				premultipliedAlpha: false,
-				powerPreference: perfTierActive() ? 'low-power' : 'default'
-			})) as WebGLRenderingContext | null;
+				powerPreference: 'low-power'
+			}) ??
+				canvas.getContext('experimental-webgl', {
+					alpha: true,
+					premultipliedAlpha: false,
+					powerPreference: 'low-power'
+				})) as WebGLRenderingContext | null;
 
-		if (!gl) {
-			console.warn('[GrungeOverlay] WebGL not available');
-			offMql?.();
-			return;
-		}
-
-		const g = gl;
-
-		const prog = g.createProgram()!;
-		const vs = compileShader(g, g.VERTEX_SHADER, VERT);
-		const fs = compileShader(g, g.FRAGMENT_SHADER, FRAG);
-		if (
-			!g.getShaderParameter(vs, g.COMPILE_STATUS) ||
-			!g.getShaderParameter(fs, g.COMPILE_STATUS)
-		) {
-			console.error('[GrungeOverlay] vertex or fragment shader failed to compile');
-			g.deleteShader(vs);
-			g.deleteShader(fs);
-			g.deleteProgram(prog);
-			offMql?.();
-			return;
-		}
-		g.attachShader(prog, vs);
-		g.attachShader(prog, fs);
-		g.linkProgram(prog);
-		if (!g.getProgramParameter(prog, g.LINK_STATUS)) {
-			console.error('[GrungeOverlay] program link error:', g.getProgramInfoLog(prog));
-			g.deleteShader(vs);
-			g.deleteShader(fs);
-			g.deleteProgram(prog);
-			offMql?.();
-			return;
-		}
-		g.deleteShader(vs);
-		g.deleteShader(fs);
-		g.useProgram(prog);
-
-		const buf = g.createBuffer();
-		g.bindBuffer(g.ARRAY_BUFFER, buf);
-		g.bufferData(g.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), g.STATIC_DRAW);
-		const aloc = g.getAttribLocation(prog, 'a_pos');
-		if (aloc < 0) {
-			console.error('[GrungeOverlay] a_pos not found in program');
-			offMql?.();
-			g.deleteProgram(prog);
-			g.deleteBuffer(buf);
-			return;
-		}
-		g.enableVertexAttribArray(aloc);
-		g.vertexAttribPointer(aloc, 2, g.FLOAT, false, 0, 0);
-
-		g.enable(g.BLEND);
-		g.blendFunc(g.SRC_ALPHA, g.ONE_MINUS_SRC_ALPHA);
-
-		const uTime = g.getUniformLocation(prog, 'u_time');
-		const uOp = g.getUniformLocation(prog, 'u_opacity');
-		const uSc = g.getUniformLocation(prog, 'u_scale');
-		const uSp = g.getUniformLocation(prog, 'u_speed');
-		const uRes = g.getUniformLocation(prog, 'u_res');
-		const uDark = g.getUniformLocation(prog, 'u_dark');
-
-		const mqMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-		function effectiveDevicePixelRatio(): number {
-			const raw = devicePixelRatio || 1;
-			if (perfTierActive()) {
-				/* Mobile GPUs choke on full 2× retina over the whole viewport; ~1–1.25× is enough for grain. */
-				return Math.min(1.25, raw);
+			if (!gl) {
+				console.warn('[GrungeOverlay] WebGL not available');
+				return;
 			}
-			return Math.min(2, raw);
-		}
 
-		function render(t: number) {
+			const g = gl;
+
+			const prog = g.createProgram()!;
+			const vs = compileShader(g, g.VERTEX_SHADER, VERT);
+			const fs = compileShader(g, g.FRAGMENT_SHADER, FRAG);
+			if (
+				!g.getShaderParameter(vs, g.COMPILE_STATUS) ||
+				!g.getShaderParameter(fs, g.COMPILE_STATUS)
+			) {
+				console.error('[GrungeOverlay] vertex or fragment shader failed to compile');
+				g.deleteShader(vs);
+				g.deleteShader(fs);
+				g.deleteProgram(prog);
+				return;
+			}
+			g.attachShader(prog, vs);
+			g.attachShader(prog, fs);
+			g.linkProgram(prog);
+			if (!g.getProgramParameter(prog, g.LINK_STATUS)) {
+				console.error('[GrungeOverlay] program link error:', g.getProgramInfoLog(prog));
+				g.deleteShader(vs);
+				g.deleteShader(fs);
+				g.deleteProgram(prog);
+				return;
+			}
+			g.deleteShader(vs);
+			g.deleteShader(fs);
 			g.useProgram(prog);
+
+			const buf = g.createBuffer();
 			g.bindBuffer(g.ARRAY_BUFFER, buf);
+			g.bufferData(g.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), g.STATIC_DRAW);
+			const aloc = g.getAttribLocation(prog, 'a_pos');
+			if (aloc < 0) {
+				console.error('[GrungeOverlay] a_pos not found in program');
+				g.deleteProgram(prog);
+				g.deleteBuffer(buf);
+				return;
+			}
 			g.enableVertexAttribArray(aloc);
 			g.vertexAttribPointer(aloc, 2, g.FLOAT, false, 0, 0);
-			g.clearColor(0, 0, 0, 0);
-			g.clear(g.COLOR_BUFFER_BIT);
-			g.uniform1f(uTime, t);
-			g.uniform1f(uOp, opacity);
-			g.uniform1f(uSc, scale);
-			g.uniform1f(uSp, speed);
-			g.uniform2f(uRes, canvas.width, canvas.height);
-			g.uniform1f(uDark, mode === 'dark' ? 1.0 : 0.0);
-			g.drawArrays(g.TRIANGLE_STRIP, 0, 4);
-		}
 
-		function redrawIfStatic() {
-			if (mqMotion.matches) render(0);
-		}
+			g.enable(g.BLEND);
+			g.blendFunc(g.SRC_ALPHA, g.ONE_MINUS_SRC_ALPHA);
 
-		const setSize = () => {
-			const dpr = effectiveDevicePixelRatio();
-			const rect = host.getBoundingClientRect();
-			let cssW = rect.width;
-			let cssH = rect.height;
-			if (cssW < 2 || cssH < 2) {
-				cssW = window.innerWidth;
-				cssH = window.innerHeight;
+			const uTime = g.getUniformLocation(prog, 'u_time');
+			const uOp = g.getUniformLocation(prog, 'u_opacity');
+			const uSc = g.getUniformLocation(prog, 'u_scale');
+			const uSp = g.getUniformLocation(prog, 'u_speed');
+			const uRes = g.getUniformLocation(prog, 'u_res');
+			const uDark = g.getUniformLocation(prog, 'u_dark');
+
+			const mqMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+			/** Cap fill-rate everywhere; highPerf QA can opt into full retina. */
+			function effectiveDevicePixelRatio(): number {
+				const raw = devicePixelRatio || 1;
+				if (highPerf) return Math.min(2, raw);
+				return Math.min(1.25, raw);
 			}
-			const w = Math.max(1, Math.floor(cssW * dpr));
-			const h = Math.max(1, Math.floor(cssH * dpr));
-			if (w !== canvas.width || h !== canvas.height) {
-				canvas.width = w;
-				canvas.height = h;
-				g.viewport(0, 0, w, h);
-			}
-			redrawIfStatic();
-		};
 
-		const ro = new ResizeObserver(() => {
+			function render(t: number) {
+				g.useProgram(prog);
+				g.bindBuffer(g.ARRAY_BUFFER, buf);
+				g.enableVertexAttribArray(aloc);
+				g.vertexAttribPointer(aloc, 2, g.FLOAT, false, 0, 0);
+				g.clearColor(0, 0, 0, 0);
+				g.clear(g.COLOR_BUFFER_BIT);
+				g.uniform1f(uTime, t);
+				g.uniform1f(uOp, opacity);
+				g.uniform1f(uSc, scale);
+				g.uniform1f(uSp, speed);
+				g.uniform2f(uRes, canvas.width, canvas.height);
+				g.uniform1f(uDark, mode === 'dark' ? 1.0 : 0.0);
+				g.drawArrays(g.TRIANGLE_STRIP, 0, 4);
+			}
+
+			function redrawIfStatic() {
+				if (mqMotion.matches) render(0);
+			}
+
+			const setSize = () => {
+				const dpr = effectiveDevicePixelRatio();
+				const rect = host.getBoundingClientRect();
+				let cssW = rect.width;
+				let cssH = rect.height;
+				if (cssW < 2 || cssH < 2) {
+					cssW = window.innerWidth;
+					cssH = window.innerHeight;
+				}
+				const w = Math.max(1, Math.floor(cssW * dpr));
+				const h = Math.max(1, Math.floor(cssH * dpr));
+				if (w !== canvas.width || h !== canvas.height) {
+					canvas.width = w;
+					canvas.height = h;
+					g.viewport(0, 0, w, h);
+				}
+				redrawIfStatic();
+			};
+
+			const ro = new ResizeObserver(() => {
+				setSize();
+			});
+			ro.observe(host);
 			setSize();
-		});
-		ro.observe(host);
-		setSize();
-		requestAnimationFrame(() => {
-			setSize();
-		});
+			requestAnimationFrame(() => {
+				setSize();
+			});
 
-		let tStart = performance.now();
-		let lastFrameAt = 0;
+			let tStart = performance.now();
+			let lastFrameAt = 0;
+			let scrolling = false;
+			let scrollResumeId: ReturnType<typeof setTimeout> | undefined;
+			const FRAME_MS = highPerf ? 0 : 1000 / 30;
+			const SCROLL_RESUME_MS = 150;
 
-		function frameBudgetMs(): number {
-			return perfTierActive() ? 1000 / 30 : 0;
-		}
-
-		function tick(now: number) {
-			if (mqMotion.matches) return;
-			if (document.visibilityState === 'hidden') {
-				return;
-			}
-			const minMs = frameBudgetMs();
-			if (minMs > 0 && now - lastFrameAt < minMs) {
-				animId = requestAnimationFrame(tick);
-				return;
-			}
-			lastFrameAt = now;
-			const t = (performance.now() - tStart) / 1000;
-			render(t);
-			animId = requestAnimationFrame(tick);
-		}
-
-		function onVisibilityChange() {
-			if (document.visibilityState === 'hidden') {
+			function startLoop() {
+				if (mqMotion.matches || document.visibilityState === 'hidden' || scrolling) return;
 				cancelAnimationFrame(animId);
-			} else if (!mqMotion.matches) {
-				tStart = performance.now();
 				lastFrameAt = 0;
-				cancelAnimationFrame(animId);
 				animId = requestAnimationFrame(tick);
 			}
-		}
 
-		function onPerfTierChange() {
-			setSize();
-			if (!mqMotion.matches && document.visibilityState !== 'hidden') {
-				tStart = performance.now();
-				lastFrameAt = 0;
+			function tick(now: number) {
+				if (mqMotion.matches || scrolling) return;
+				if (document.visibilityState === 'hidden') return;
+				if (FRAME_MS > 0 && now - lastFrameAt < FRAME_MS) {
+					animId = requestAnimationFrame(tick);
+					return;
+				}
+				lastFrameAt = now;
+				const t = (performance.now() - tStart) / 1000;
+				render(t);
+				animId = requestAnimationFrame(tick);
 			}
-		}
 
-		function onMotionChange() {
-			cancelAnimationFrame(animId);
+			function onScroll() {
+				if (mqMotion.matches) return;
+				if (!scrolling) {
+					scrolling = true;
+					cancelAnimationFrame(animId);
+				}
+				if (scrollResumeId !== undefined) clearTimeout(scrollResumeId);
+				scrollResumeId = setTimeout(() => {
+					scrolling = false;
+					scrollResumeId = undefined;
+					tStart = performance.now();
+					startLoop();
+				}, SCROLL_RESUME_MS);
+			}
+
+			function onVisibilityChange() {
+				if (document.visibilityState === 'hidden') {
+					cancelAnimationFrame(animId);
+				} else if (!mqMotion.matches && !scrolling) {
+					tStart = performance.now();
+					startLoop();
+				}
+			}
+
+			function onMotionChange() {
+				cancelAnimationFrame(animId);
+				if (mqMotion.matches) {
+					render(0);
+				} else if (!scrolling) {
+					tStart = performance.now();
+					startLoop();
+				}
+			}
+
+			if (modeProp === undefined) {
+				const mq = window.matchMedia('(prefers-color-scheme: dark)');
+				const onScheme = () => {
+					mode = mq.matches ? 'dark' : 'light';
+					redrawIfStatic();
+				};
+				mq.addEventListener('change', onScheme);
+				offMql = () => mq.removeEventListener('change', onScheme);
+			}
+
+			mqMotion.addEventListener('change', onMotionChange);
+			document.addEventListener('visibilitychange', onVisibilityChange);
+			window.addEventListener('scroll', onScroll, { passive: true });
+
 			if (mqMotion.matches) {
 				render(0);
 			} else {
-				tStart = performance.now();
-				lastFrameAt = 0;
-				animId = requestAnimationFrame(tick);
+				startLoop();
 			}
-		}
 
-		if (modeProp === undefined) {
-			const mq = window.matchMedia('(prefers-color-scheme: dark)');
-			const onScheme = () => {
-				mode = mq.matches ? 'dark' : 'light';
-				redrawIfStatic();
+			disposeGl = () => {
+				offMql?.();
+				offMql = undefined;
+				document.removeEventListener('visibilitychange', onVisibilityChange);
+				mqMotion.removeEventListener('change', onMotionChange);
+				window.removeEventListener('scroll', onScroll);
+				if (scrollResumeId !== undefined) clearTimeout(scrollResumeId);
+				cancelAnimationFrame(animId);
+				ro.disconnect();
+				g.deleteProgram(prog);
+				g.deleteBuffer(buf);
 			};
-			mq.addEventListener('change', onScheme);
-			offMql = () => mq.removeEventListener('change', onScheme);
 		}
 
-		mqMotion.addEventListener('change', onMotionChange);
-		document.addEventListener('visibilitychange', onVisibilityChange);
-		mqPerf.addEventListener('change', onPerfTierChange);
-
-		if (mqMotion.matches) {
-			render(0);
-		} else {
-			animId = requestAnimationFrame(tick);
-		}
+		scheduleAfterPaint(startWebGl);
 
 		return () => {
-			offMql?.();
-			document.removeEventListener('visibilitychange', onVisibilityChange);
-			mqPerf.removeEventListener('change', onPerfTierChange);
-			mqMotion.removeEventListener('change', onMotionChange);
-			cancelAnimationFrame(animId);
-			ro.disconnect();
-			g.deleteProgram(prog);
-			g.deleteBuffer(buf);
+			cancelled = true;
+			const cancelIdle = (
+				window as Window & { cancelIdleCallback?: (id: number) => void }
+			).cancelIdleCallback;
+			if (idleId !== undefined && typeof cancelIdle === 'function') cancelIdle(idleId);
+			if (idleTimeoutId !== undefined) clearTimeout(idleTimeoutId);
+			disposeGl?.();
 		};
 	});
 </script>

--- a/src/lib/components/LastFmNowPlaying/LastFmNowPlaying.svelte
+++ b/src/lib/components/LastFmNowPlaying/LastFmNowPlaying.svelte
@@ -175,14 +175,49 @@
 			void 0;
 		}
 
-		fetchNowPlaying();
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+		let idleId: number | undefined;
+		let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
+		let cancelled = false;
 
-		const intervalId = setInterval(() => {
-			fetchNowPlaying();
-		}, refreshIntervalMs);
+		function startPolling() {
+			if (cancelled) return;
+			void fetchNowPlaying();
+			intervalId = setInterval(() => {
+				if (document.visibilityState === 'hidden') return;
+				void fetchNowPlaying();
+			}, refreshIntervalMs);
+		}
+
+		function onVisibilityChange() {
+			if (document.visibilityState === 'visible' && !cancelled) {
+				void fetchNowPlaying();
+			}
+		}
+
+		// Defer network + interval until after first paint so every page's critical path stays clear.
+		const ric = (
+			window as Window & {
+				requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+			}
+		).requestIdleCallback;
+		if (typeof ric === 'function') {
+			idleId = ric(startPolling, { timeout: 3000 });
+		} else {
+			idleTimeoutId = setTimeout(startPolling, 1500);
+		}
+
+		document.addEventListener('visibilitychange', onVisibilityChange);
 
 		return () => {
-			clearInterval(intervalId);
+			cancelled = true;
+			const cancelIdle = (
+				window as Window & { cancelIdleCallback?: (id: number) => void }
+			).cancelIdleCallback;
+			if (idleId !== undefined && typeof cancelIdle === 'function') cancelIdle(idleId);
+			if (idleTimeoutId !== undefined) clearTimeout(idleTimeoutId);
+			if (intervalId !== null) clearInterval(intervalId);
+			document.removeEventListener('visibilitychange', onVisibilityChange);
 		};
 	});
 </script>

--- a/src/lib/components/LastFmNowPlaying/LastFmNowPlayingLazy.svelte
+++ b/src/lib/components/LastFmNowPlaying/LastFmNowPlayingLazy.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	/**
+	 * Defers Last.fm widget JS/network until after first paint so it stays off
+	 * the critical path on every (site) page.
+	 */
+	import { browser } from '$app/environment';
+	import type { Component } from 'svelte';
+	import { onMount } from 'svelte';
+
+	let Widget = $state<Component | null>(null);
+
+	onMount(() => {
+		if (!browser) return;
+
+		let cancelled = false;
+		let idleId: number | undefined;
+		let idleTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+		function load() {
+			if (cancelled) return;
+			void import('$lib/components/LastFmNowPlaying/LastFmNowPlaying.svelte').then((mod) => {
+				if (!cancelled) Widget = mod.default;
+			});
+		}
+
+		const ric = (
+			window as Window & {
+				requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+			}
+		).requestIdleCallback;
+		if (typeof ric === 'function') {
+			idleId = ric(load, { timeout: 4000 });
+		} else {
+			idleTimeoutId = setTimeout(load, 2000);
+		}
+
+		return () => {
+			cancelled = true;
+			const cancelIdle = (
+				window as Window & { cancelIdleCallback?: (id: number) => void }
+			).cancelIdleCallback;
+			if (idleId !== undefined && typeof cancelIdle === 'function') cancelIdle(idleId);
+			if (idleTimeoutId !== undefined) clearTimeout(idleTimeoutId);
+		};
+	});
+</script>
+
+{#if Widget}
+	<Widget />
+{/if}

--- a/src/lib/components/NavigationProgress/NavigationProgress.svelte
+++ b/src/lib/components/NavigationProgress/NavigationProgress.svelte
@@ -8,10 +8,18 @@
 	let isVisible = $state(false);
 	let intervalId: ReturnType<typeof setInterval> | null = null;
 
+	function clearProgressInterval() {
+		if (intervalId !== null) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+	}
+
 	beforeNavigate(() => {
 		// Don't show the loading bar for silent background refreshes.
 		if (get(isSilentRefresh)) return;
 
+		clearProgressInterval();
 		isVisible = true;
 		progress = 0;
 
@@ -24,6 +32,7 @@
 	});
 
 	afterNavigate(() => {
+		clearProgressInterval();
 		if (!isVisible) return;
 
 		progress = 100;
@@ -36,9 +45,7 @@
 
 	onMount(() => {
 		return () => {
-			if (intervalId) {
-				clearInterval(intervalId);
-			}
+			clearProgressInterval();
 		};
 	});
 </script>

--- a/src/lib/query/client.ts
+++ b/src/lib/query/client.ts
@@ -4,7 +4,7 @@ import { QueryClient } from '@tanstack/svelte-query';
 export const SWR_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
 /** How long an unused/persisted query is retained before garbage collection. */
-export const SWR_GC_TIME_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const SWR_GC_TIME_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
  * A fresh QueryClient per SSR request / browser session. Defaults implement the

--- a/src/lib/query/idbPersister.ts
+++ b/src/lib/query/idbPersister.ts
@@ -129,6 +129,7 @@ export function createIdbPersister(): Persister {
 	return createAsyncStoragePersister({
 		storage: browser ? idbStorage : noopStorage,
 		key: QUERY_CACHE_STORAGE_KEY,
-		throttleTime: 1000
+		// Avoid serializing the full cache on every rapid query update.
+		throttleTime: 2500
 	});
 }

--- a/src/lib/query/shouldPersistQuery.test.ts
+++ b/src/lib/query/shouldPersistQuery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { shouldPersistQuery } from './shouldPersistQuery';
+import type { Query } from '@tanstack/svelte-query';
+
+vi.mock('@tanstack/svelte-query', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@tanstack/svelte-query')>();
+	return {
+		...actual,
+		defaultShouldDehydrateQuery: (query: Query) => query.state.status === 'success'
+	};
+});
+
+function fakeQuery(queryKey: unknown[], status: Query['state']['status'] = 'success'): Query {
+	return {
+		queryKey,
+		state: { status }
+	} as unknown as Query;
+}
+
+describe('shouldPersistQuery', () => {
+	it('persists layout, article lists, and projects', () => {
+		expect(shouldPersistQuery(fakeQuery(['layout']))).toBe(true);
+		expect(shouldPersistQuery(fakeQuery(['articles', 'list', {}]))).toBe(true);
+		expect(shouldPersistQuery(fakeQuery(['projects', 1, 10]))).toBe(true);
+	});
+
+	it('skips full article bodies', () => {
+		expect(shouldPersistQuery(fakeQuery(['article', 'my-slug']))).toBe(false);
+	});
+
+	it('skips non-success queries', () => {
+		expect(shouldPersistQuery(fakeQuery(['layout'], 'pending'))).toBe(false);
+	});
+});

--- a/src/lib/query/shouldPersistQuery.ts
+++ b/src/lib/query/shouldPersistQuery.ts
@@ -1,0 +1,14 @@
+import { defaultShouldDehydrateQuery, type Query } from '@tanstack/svelte-query';
+
+/**
+ * Persist layout + list stubs for offline/SWR, but skip full article bodies
+ * (Lexical JSON) which dominate IndexedDB size and main-thread serialize cost.
+ */
+export function shouldPersistQuery(query: Query): boolean {
+	if (!defaultShouldDehydrateQuery(query)) return false;
+
+	const root = query.queryKey[0];
+	if (root === 'article') return false;
+	if (root === 'layout' || root === 'articles' || root === 'projects') return true;
+	return false;
+}

--- a/src/routes/(site)/+layout.server.ts
+++ b/src/routes/(site)/+layout.server.ts
@@ -1,9 +1,15 @@
 import { loadSession } from '$lib/auth/loadSession.server';
+import type { LayoutCacheData } from '$lib/cache/layoutCache';
 import type { LayoutServerLoad } from './$types';
 
-/** Server-side session for +page.server.ts guards (universal +layout.ts data is not in parent() on client nav). */
+/** Server-side session + layout seed for every (site) document load. */
 export const load: LayoutServerLoad = async ({ fetch, request }) => {
-	return {
-		session: await loadSession(fetch, request)
-	};
+	const [session, initialLayout] = await Promise.all([
+		loadSession(fetch, request),
+		fetch('/api/layout-data')
+			.then(async (res) => (res.ok ? ((await res.json()) as LayoutCacheData) : null))
+			.catch(() => null)
+	]);
+
+	return { session, initialLayout };
 };

--- a/src/routes/(site)/+layout.svelte
+++ b/src/routes/(site)/+layout.svelte
@@ -3,6 +3,7 @@
 	import { PersistQueryClientProvider } from '@tanstack/svelte-query-persist-client';
 	import { createQueryClient, SWR_GC_TIME_MS } from '$lib/query/client';
 	import { createIdbPersister } from '$lib/query/idbPersister';
+	import { shouldPersistQuery } from '$lib/query/shouldPersistQuery';
 	import SiteChrome from './SiteChrome.svelte';
 	import type { LayoutProps } from './$types';
 	import './styles.css';
@@ -14,6 +15,12 @@
 
 	onNavigate(async (navigation) => {
 		if (!document.startViewTransition) return;
+		// Skip expensive view transitions on constrained devices / user prefs.
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+		const conn = (navigator as Navigator & { connection?: { saveData?: boolean; effectiveType?: string } })
+			.connection;
+		if (conn?.saveData) return;
+		if (conn?.effectiveType === '2g' || conn?.effectiveType === 'slow-2g') return;
 
 		return new Promise((oldStateCaptureResolve) => {
 			document.startViewTransition(async () => {
@@ -26,7 +33,15 @@
 
 <PersistQueryClientProvider
 	client={queryClient}
-	persistOptions={{ persister, maxAge: SWR_GC_TIME_MS }}
+	persistOptions={{
+		persister,
+		maxAge: SWR_GC_TIME_MS,
+		// Bust caches written before article-body exclusion / shorter maxAge.
+		buster: 'v2-no-article-bodies',
+		dehydrateOptions: {
+			shouldDehydrateQuery: shouldPersistQuery
+		}
+	}}
 >
 	<SiteChrome {data}>
 		{@render children?.()}

--- a/src/routes/(site)/+layout.ts
+++ b/src/routes/(site)/+layout.ts
@@ -10,26 +10,17 @@ export const load: LayoutLoad = async (event) => {
 
 	const parentData = (await event.parent()) as {
 		session?: Awaited<ReturnType<typeof loadSession>>;
+		initialLayout?: LayoutCacheData | null;
 	};
 	const request = 'request' in event ? (event.request as Request) : undefined;
-	// Client: always refresh (e.g. after login). SSR: reuse +layout.server.ts when available.
+
+	// Client: always refresh session (e.g. after login). SSR: reuse server layout.
 	const session = browser
 		? await loadSession(event.fetch, request)
 		: (parentData.session ?? (await loadSession(event.fetch, request)));
 
-	// SSR seed so navigation/meta are present in the initial HTML. In the browser
-	// the persisted TanStack cache provides instant data and revalidation.
-	let initialLayout: LayoutCacheData | null = null;
-	if (!browser) {
-		try {
-			const res = await event.fetch('/api/layout-data');
-			if (res.ok) {
-				initialLayout = (await res.json()) as LayoutCacheData;
-			}
-		} catch {
-			initialLayout = null;
-		}
-	}
+	// SSR seed comes from +layout.server.ts (fetched in parallel with session).
+	const initialLayout = browser ? null : (parentData.initialLayout ?? null);
 
 	return { session, initialLayout };
 };

--- a/src/routes/(site)/SiteChrome.svelte
+++ b/src/routes/(site)/SiteChrome.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { createQuery } from '@tanstack/svelte-query';
 	import NavigationProgress from '$lib/components/NavigationProgress';
-	import LastFmNowPlaying from '$lib/components/LastFmNowPlaying';
+	import LastFmNowPlayingLazy from '$lib/components/LastFmNowPlaying/LastFmNowPlayingLazy.svelte';
 	import Footer from '$lib/components/Footer';
 	import Header from '$lib/components/Header';
 	import Meta from '$lib/components/meta/Meta';
 	import Navigation from '$lib/components/navigation/Navigation';
 	import GrungeOverlay from '$lib/components/GrungeOverlay';
-	import AdminUtilitiesDock from '$lib/components/AdminUtilitiesDock';
+	import AdminUtilitiesDockLazy from '$lib/components/AdminUtilitiesDock/AdminUtilitiesDockLazy.svelte';
 	import TopBar from '$lib/components/TopBar';
 	import type { LayoutCacheData } from '$lib/cache/layoutCache';
 	import { layoutQueryOptions } from '$lib/query/queries';
@@ -46,8 +46,8 @@
 			</main>
 		</div>
 		<Footer />
-		<LastFmNowPlaying />
-		<AdminUtilitiesDock />
+		<LastFmNowPlayingLazy />
+		<AdminUtilitiesDockLazy />
 	</div>
 </div>
 


### PR DESCRIPTION
## Summary
- Throttle/defer GrungeOverlay WebGL (DPR, ~30fps, scroll-pause) and slim Google Fonts axes site-wide
- Code-split AdminUtilitiesDock + Last.fm off the public critical path; fix NavigationProgress interval leak
- Trim TanStack IDB persistence (no article bodies, 7-day maxAge) and parallelize SSR session + layout-data fetches

## Test plan
- [ ] Load `/` and a few other routes (articles, models, galleries) — scroll should feel smoother; no console errors
- [ ] Confirm admin dock still appears/works when logged in as admin
- [ ] Confirm Last.fm widget still appears after a short delay when something is playing
- [ ] Offline/SWR: layout + list pages still restore from IndexedDB; full article bodies are refetched rather than persisted
- [ ] Re-run PageSpeed / Lighthouse on `/` after deploy and compare TBT / LCP vs prior ~48–61


Made with [Cursor](https://cursor.com)