### PR TITLE
Restore font swap and Source Code Pro 300 for nav.

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@300;400;500;600;700&family=Permanent+Marker&family=Roboto:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,700&family=Source+Code+Pro:wght@400;500;600;700&family=Special+Elite&family=Delius&display=optional"
+			href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400;1,600&family=Oswald:wght@300;400;500;600;700&family=Permanent+Marker&family=Roboto:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,700&family=Source+Code+Pro:wght@300;400;500;600;700&family=Special+Elite&family=Delius&display=swap"
 			rel="stylesheet"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
display=optional was preventing webfonts from ever applying after the short block window, and the nav’s weight 300 had no matching face loaded.