### PR TITLE
Ship admin previews, PhotoSwipe zoom, and gallery UX polish (v0.21.0).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "www-itsmillertime-dev",
 	"private": true,
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"type": "module",
 	"scripts": {
 		"dev": "pnpm run fetch-payload-types && vite dev",
@@ -68,6 +68,7 @@
 		"highlight.js": "^11.11.1",
 		"maplibre-gl": "^5.16.0",
 		"media-chrome": "^4.17.2",
+		"photoswipe": "^5.4.4",
 		"qs-esm": "^7.0.3",
 		"satori": "^0.19.1",
 		"sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       media-chrome:
         specifier: ^4.17.2
         version: 4.17.2(react@19.2.3)
+      photoswipe:
+        specifier: ^5.4.4
+        version: 5.4.4
       qs-esm:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2664,6 +2667,10 @@ packages:
   peek-readable@5.4.2:
     resolution: {integrity: sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==}
     engines: {node: '>=14.16'}
+
+  photoswipe@5.4.4:
+    resolution: {integrity: sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==}
+    engines: {node: '>= 0.12.0'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5835,6 +5842,8 @@ snapshots:
       resolve-protobuf-schema: 2.1.0
 
   peek-readable@5.4.2: {}
+
+  photoswipe@5.4.4: {}
 
   picocolors@1.1.1: {}
 

--- a/src/lib/cache/articleCache.server.ts
+++ b/src/lib/cache/articleCache.server.ts
@@ -3,8 +3,20 @@ import { getPayloadSDK } from '$lib/payload/sdk.server';
 import type { Post } from '$lib/types/payload-types';
 import { toRelatedLinks } from '$lib/utils/relatedResources';
 
-function isPublishedArticle(article: Post | null | undefined): article is Post {
-	return article?._status === 'published';
+export type ArticlePageLoadOptions = {
+	/** When true, allow draft posts (admin preview). Requires auth cookies via fetch/request. */
+	includeDrafts?: boolean;
+	fetch?: typeof globalThis.fetch;
+	request?: Request;
+};
+
+function isReadableArticle(
+	article: Post | null | undefined,
+	includeDrafts: boolean
+): article is Post {
+	if (!article) return false;
+	if (includeDrafts) return true;
+	return article._status === 'published';
 }
 
 export function buildArticlePageMeta(doc: Post, origin: string, slug: string): ArticlePageMeta {
@@ -13,21 +25,28 @@ export function buildArticlePageMeta(doc: Post, origin: string, slug: string): A
 		: { canonicalURL: `${origin}/articles/${slug}` };
 }
 
-async function fetchArticleByIdFromCMS(articleId: number | string): Promise<Post | null> {
-	const sdk = getPayloadSDK();
+async function fetchArticleByIdFromCMS(
+	articleId: number | string,
+	options: ArticlePageLoadOptions = {}
+): Promise<Post | null> {
+	const { includeDrafts = false, fetch, request } = options;
+	const sdk = getPayloadSDK(fetch, request);
 	return sdk.findByID({
 		collection: 'posts',
 		id: articleId,
 		depth: 1,
-		disableErrors: true
+		disableErrors: true,
+		...(includeDrafts ? { draft: true } : {})
 	});
 }
 
 /** Models that list this article under relatedResources.relatedPosts (CMS has no article→model field). */
 async function fetchModelsRelatedToArticle(
-	articleId: number | string
+	articleId: number | string,
+	options: ArticlePageLoadOptions = {}
 ): Promise<ArticleRelatedModel[]> {
-	const sdk = getPayloadSDK();
+	const { fetch, request } = options;
+	const sdk = getPayloadSDK(fetch, request);
 	const result = await sdk.find({
 		collection: 'models',
 		limit: 50,
@@ -47,20 +66,31 @@ async function fetchModelsRelatedToArticle(
 	return toRelatedLinks(result.docs);
 }
 
-async function resolvePublishedArticleId(slug: string): Promise<number | string | null> {
-	const sdk = getPayloadSDK();
+async function resolveArticleId(
+	slug: string,
+	options: ArticlePageLoadOptions = {}
+): Promise<number | string | null> {
+	const { includeDrafts = false, fetch, request } = options;
+	const sdk = getPayloadSDK(fetch, request);
 	const postLookup = await sdk.find({
 		collection: 'posts',
 		limit: 1,
 		select: {
 			id: true
 		},
+		...(includeDrafts ? { draft: true } : {}),
 		where: {
 			and: [
+				...(includeDrafts
+					? []
+					: [
+							{
+								_status: {
+									equals: 'published'
+								}
+							}
+						]),
 				{
-					_status: {
-						equals: 'published'
-					},
 					slug: {
 						equals: slug
 					}
@@ -81,15 +111,17 @@ export type ArticlePageDataResult = {
 
 export async function loadArticlePageData(
 	slug: string,
-	origin: string
+	origin: string,
+	options: ArticlePageLoadOptions = {}
 ): Promise<ArticlePageDataResult | null> {
-	const articleId = await resolvePublishedArticleId(slug);
+	const includeDrafts = options.includeDrafts === true;
+	const articleId = await resolveArticleId(slug, options);
 	if (articleId == null) return null;
 
-	const doc = await fetchArticleByIdFromCMS(articleId);
-	if (!isPublishedArticle(doc)) return null;
+	const doc = await fetchArticleByIdFromCMS(articleId, options);
+	if (!isReadableArticle(doc, includeDrafts)) return null;
 
-	const relatedModels = await fetchModelsRelatedToArticle(articleId);
+	const relatedModels = await fetchModelsRelatedToArticle(articleId, options);
 
 	return {
 		article: doc,

--- a/src/lib/cache/articleListCache.server.ts
+++ b/src/lib/cache/articleListCache.server.ts
@@ -7,16 +7,31 @@ import {
 import { getPayloadSDK } from '$lib/payload/sdk.server';
 import type { Post, PostsCategory, PostsTag } from '$lib/types/payload-types';
 
-async function fetchArticlesListFromCMS(query: ArticlesListQuery): Promise<ArticlesListCacheData> {
-	const sdk = getPayloadSDK();
+export type ArticlesListLoadOptions = {
+	/** When true, include draft posts (admin preview). Requires auth cookies via fetch/request. */
+	includeDrafts?: boolean;
+	fetch?: typeof globalThis.fetch;
+	request?: Request;
+};
+
+async function fetchArticlesListFromCMS(
+	query: ArticlesListQuery,
+	options: ArticlesListLoadOptions = {}
+): Promise<ArticlesListCacheData> {
+	const { includeDrafts = false, fetch, request } = options;
+	const sdk = getPayloadSDK(fetch, request);
 	const { page, limit, category, tag, sort } = query;
 
 	const andFilters = [
-		{
-			_status: {
-				not_equals: 'draft'
-			}
-		},
+		...(includeDrafts
+			? []
+			: [
+					{
+						_status: {
+							not_equals: 'draft'
+						}
+					}
+				]),
 		...(category ? [{ 'category.slug': { equals: category } }] : []),
 		...(tag ? [{ 'tags.slug': { equals: tag } }] : [])
 	];
@@ -27,6 +42,7 @@ async function fetchArticlesListFromCMS(query: ArticlesListQuery): Promise<Artic
 			limit,
 			page,
 			sort,
+			...(includeDrafts ? { draft: true } : {}),
 			select: {
 				publishedAt: true,
 				slug: true,
@@ -39,15 +55,20 @@ async function fetchArticlesListFromCMS(query: ArticlesListQuery): Promise<Artic
 				originalPublicationDate: true,
 				category: true,
 				tags: true,
+				_status: true,
 				meta: {
 					title: true,
 					description: true,
 					image: true
 				}
 			},
-			where: {
-				and: andFilters as never[]
-			}
+			...(andFilters.length > 0
+				? {
+						where: {
+							and: andFilters as never[]
+						}
+					}
+				: {})
 		}),
 		sdk.find({
 			collection: 'posts-categories',
@@ -77,8 +98,9 @@ export async function loadArticlesListPageData(
 	limitRaw: number,
 	categoryRaw?: string | null,
 	tagRaw?: string | null,
-	sortRaw?: string | null
+	sortRaw?: string | null,
+	options: ArticlesListLoadOptions = {}
 ): Promise<ArticlesListCacheData> {
 	const query = normalizeArticlesQuery(pageRaw, limitRaw, categoryRaw, tagRaw, sortRaw);
-	return fetchArticlesListFromCMS(query);
+	return fetchArticlesListFromCMS(query, options);
 }

--- a/src/lib/components/AdminUtilitiesDock/AdminUtilitiesDock.svelte
+++ b/src/lib/components/AdminUtilitiesDock/AdminUtilitiesDock.svelte
@@ -33,6 +33,8 @@
 	let panelOpen = $state(false);
 	let activeTab = $state<AdminTab>('browser');
 	let rootEl: HTMLDivElement | undefined = $state();
+	/** True while a site lightbox / PhotoSwipe / modal dialog is open — hide the solo tab. */
+	let overlayActive = $state(false);
 
 	const cms = `${PUBLIC_PAYLOAD_URL}/admin`;
 	const cmsCollections = {
@@ -165,6 +167,36 @@
 		};
 	});
 
+	/** Hide the floating Admin tab while lightboxes/modals own the viewport. */
+	$effect(() => {
+		if (!browser) return;
+
+		function isOverlayPresent() {
+			return Boolean(
+				document.querySelector(
+					'.lightbox, .pswp, dialog[open], [aria-modal="true"]:not(.admin-dock-dialog)'
+				)
+			);
+		}
+
+		function syncOverlay() {
+			const next = isOverlayPresent();
+			if (next !== overlayActive) overlayActive = next;
+			// Don't leave the admin sheet open on top of a lightbox.
+			if (next && panelOpen) panelOpen = false;
+		}
+
+		syncOverlay();
+		const mo = new MutationObserver(syncOverlay);
+		mo.observe(document.documentElement, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ['open', 'class', 'aria-modal']
+		});
+		return () => mo.disconnect();
+	});
+
 	function closePanel() {
 		panelOpen = false;
 	}
@@ -217,7 +249,7 @@
 
 {#if isAdmin}
 	<div class="admin-dock-root" bind:this={rootEl}>
-		{#if !panelOpen}
+		{#if !panelOpen && !overlayActive}
 			<button
 				type="button"
 				class="admin-dock-tab admin-dock-tab--solo"
@@ -231,7 +263,7 @@
 			>
 				<span class="admin-dock-label">Admin</span>
 			</button>
-		{:else}
+		{:else if panelOpen}
 			<!-- svelte-ignore a11y_click_events_have_key_events -->
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
@@ -551,13 +583,22 @@
 		text-orientation: mixed;
 	}
 
+	/* Bottom-right pill — mid-right vertical tab covered lightbox/nav controls. */
 	.admin-dock-tab--solo {
 		position: fixed;
-		right: max(0px, env(safe-area-inset-right, 0px));
-		top: 50%;
-		transform: translateY(-50%);
+		right: max(0.5rem, env(safe-area-inset-right, 0px));
+		bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+		top: auto;
 		z-index: 10003;
 		pointer-events: auto;
+		writing-mode: horizontal-tb;
+		text-orientation: mixed;
+		min-width: auto;
+		padding: 0.45rem 0.85rem;
+		border-radius: 999px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		font-size: var(--fs-xs);
 	}
 
 	.admin-dock-tab--attached {

--- a/src/lib/components/Excerpt/Excerpt.svelte
+++ b/src/lib/components/Excerpt/Excerpt.svelte
@@ -20,7 +20,9 @@
 	>
 	<div class="meta">
 		<div class="pub-date" style:view-transition-name={`article-pub-date-${item.slug}`}>
-			{#if item.originalPublicationDate}
+			{#if item._status === 'draft'}
+				Draft
+			{:else if item.originalPublicationDate}
 				{new Date(item.originalPublicationDate).toLocaleDateString('en-US', {
 					year: 'numeric',
 					month: 'long',

--- a/src/lib/components/GrungeOverlay/GrungeOverlay.svelte
+++ b/src/lib/components/GrungeOverlay/GrungeOverlay.svelte
@@ -331,21 +331,17 @@
 
 			let tStart = performance.now();
 			let lastFrameAt = 0;
-			let paused = false;
-			let resumeId: ReturnType<typeof setTimeout> | undefined;
 			const FRAME_MS = highPerf ? 0 : 1000 / 30;
-			const SCROLL_RESUME_MS = 150;
-			const INTERACTION_RESUME_MS = 500;
 
 			function startLoop() {
-				if (mqMotion.matches || document.visibilityState === 'hidden' || paused) return;
+				if (mqMotion.matches || document.visibilityState === 'hidden') return;
 				cancelAnimationFrame(animId);
 				lastFrameAt = 0;
 				animId = requestAnimationFrame(tick);
 			}
 
 			function tick(now: number) {
-				if (mqMotion.matches || paused) return;
+				if (mqMotion.matches) return;
 				if (document.visibilityState === 'hidden') return;
 				if (FRAME_MS > 0 && now - lastFrameAt < FRAME_MS) {
 					animId = requestAnimationFrame(tick);
@@ -357,34 +353,10 @@
 				animId = requestAnimationFrame(tick);
 			}
 
-			function pauseTemporarily(resumeMs: number) {
-				if (mqMotion.matches) return;
-				if (!paused) {
-					paused = true;
-					cancelAnimationFrame(animId);
-				}
-				if (resumeId !== undefined) clearTimeout(resumeId);
-				resumeId = setTimeout(() => {
-					paused = false;
-					resumeId = undefined;
-					tStart = performance.now();
-					startLoop();
-				}, resumeMs);
-			}
-
-			function onScroll() {
-				pauseTemporarily(SCROLL_RESUME_MS);
-			}
-
-			/** Free GPU/main thread during clicks so INP isn't fighting WebGL. */
-			function pauseForInteraction() {
-				pauseTemporarily(INTERACTION_RESUME_MS);
-			}
-
 			function onVisibilityChange() {
 				if (document.visibilityState === 'hidden') {
 					cancelAnimationFrame(animId);
-				} else if (!mqMotion.matches && !paused) {
+				} else if (!mqMotion.matches) {
 					tStart = performance.now();
 					startLoop();
 				}
@@ -394,7 +366,7 @@
 				cancelAnimationFrame(animId);
 				if (mqMotion.matches) {
 					render(0);
-				} else if (!paused) {
+				} else {
 					tStart = performance.now();
 					startLoop();
 				}
@@ -412,9 +384,6 @@
 
 			mqMotion.addEventListener('change', onMotionChange);
 			document.addEventListener('visibilitychange', onVisibilityChange);
-			window.addEventListener('scroll', onScroll, { passive: true });
-			document.addEventListener('pointerdown', pauseForInteraction, { capture: true, passive: true });
-			document.addEventListener('keydown', pauseForInteraction, { capture: true, passive: true });
 
 			if (mqMotion.matches) {
 				render(0);
@@ -427,10 +396,6 @@
 				offMql = undefined;
 				document.removeEventListener('visibilitychange', onVisibilityChange);
 				mqMotion.removeEventListener('change', onMotionChange);
-				window.removeEventListener('scroll', onScroll);
-				document.removeEventListener('pointerdown', pauseForInteraction, true);
-				document.removeEventListener('keydown', pauseForInteraction, true);
-				if (resumeId !== undefined) clearTimeout(resumeId);
 				cancelAnimationFrame(animId);
 				ro.disconnect();
 				g.deleteProgram(prog);

--- a/src/lib/components/Icon/Icon.svelte
+++ b/src/lib/components/Icon/Icon.svelte
@@ -13,6 +13,7 @@
 			| 'square'
 			| 'book'
 			| 'link'
+			| 'external-link'
 			| 'eye';
 		size?: number;
 		color?: string;
@@ -76,6 +77,10 @@
 	{:else if name === 'link'}
 		<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
 		<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+	{:else if name === 'external-link'}
+		<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+		<polyline points="15 3 21 3 21 9"></polyline>
+		<line x1="10" y1="14" x2="21" y2="3"></line>
 	{:else if name === 'eye'}
 		<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
 		<circle cx="12" cy="12" r="3"></circle>

--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { fade, scale, fly } from 'svelte/transition';
-	import { quintOut } from 'svelte/easing';
+	import { onDestroy } from 'svelte';
 	import { page } from '$app/state';
 	import type { Media } from '$lib/types/payload-types';
 	import Icon from '$lib/components/Icon';
 	import { getMediaUrl, isGifMedia } from '$lib/utils/media-url';
+	import { mediaToPhotoSwipeSlide } from '$lib/utils/photoswipe/media-to-slide';
 	import { preventContextMenu } from '$lib/utils/prevent-context-menu';
+	import type PhotoSwipe from 'photoswipe';
 
 	// All size keys to inspect — mimeType on each entry determines which <source> it belongs to
 	const ALL_SIZE_KEYS = ['thumbnail', 'small', 'medium', 'large', 'xlarge'] as const;
@@ -81,9 +82,8 @@
 	let nsfwRevealed = $state(false);
 	let isLoaded = $state(false);
 	let isLoadFailed = $state(false);
-	let lightboxDialog: HTMLDialogElement | undefined | null = $state(null);
-	let currentGalleryIndex = $state(0);
-	let imageTransitionDirection = $state<'left' | 'right'>('right');
+	let thumbImg: HTMLImageElement | null = $state(null);
+	let pswpInstance: PhotoSwipe | null = null;
 
 	const aspectRatioStyle = $derived.by(() => {
 		if (fixedAspectRatio != null) return String(fixedAspectRatio);
@@ -106,70 +106,55 @@
 	// Fallback src for the <img> tag — always the original JPEG
 	const src = $derived(image?.url ? getMediaUrl(image.url, useProxy) : '');
 
-	const currentLightboxImage = $derived(gallery ? gallery[currentGalleryIndex] : image);
-	const hasGallery = $derived(gallery != null && gallery.length > 1);
-	const canGoPrev = $derived(hasGallery && currentGalleryIndex > 0);
-	const canGoNext = $derived(hasGallery && currentGalleryIndex < (gallery?.length ?? 0) - 1);
+	async function openLightbox() {
+		const items = gallery && gallery.length > 0 ? gallery : [image];
+		const startIndex = gallery ? galleryIndex : 0;
+		const thumbCropped = objectFit === 'cover';
 
-	// Lightbox srcsets track the current gallery image (changes as user navigates)
-	const lightboxSrcsets = $derived(buildSrcsets(currentLightboxImage));
+		const dataSource = items.map((item, index) =>
+			mediaToPhotoSwipeSlide(item, {
+				useProxy,
+				element: index === startIndex ? thumbImg : null,
+				thumbCropped
+			})
+		);
 
-	function openLightbox() {
-		if (!lightboxDialog) return;
-		currentGalleryIndex = galleryIndex;
-		lightboxDialog.showModal();
-		document.body.style.overflow = 'hidden';
-	}
+		const [{ default: PhotoSwipe }] = await Promise.all([
+			import('photoswipe'),
+			import('photoswipe/style.css')
+		]);
 
-	function closeLightbox() {
-		if (!lightboxDialog) return;
-		lightboxDialog.close();
-		document.body.style.overflow = '';
-	}
+		pswpInstance?.destroy();
 
-	function goToPrevImage() {
-		if (canGoPrev) {
-			imageTransitionDirection = 'left';
-			currentGalleryIndex--;
+		const pswp = new PhotoSwipe({
+			dataSource,
+			index: startIndex,
+			bgOpacity: 0.95,
+			showHideAnimationType: 'zoom',
+			wheelToZoom: true,
+			pinchToClose: false,
+			// Keep UI chrome minimal; zoom/pan/pinch are the point.
+			padding: { top: 24, bottom: 24, left: 16, right: 16 }
+		});
+
+		if (disableContextMenu) {
+			pswp.on('contentActivate', ({ content }) => {
+				content.element?.addEventListener('contextmenu', preventContextMenu);
+			});
 		}
+
+		pswp.on('destroy', () => {
+			if (pswpInstance === pswp) pswpInstance = null;
+		});
+
+		pswpInstance = pswp;
+		pswp.init();
 	}
 
-	function goToNextImage() {
-		if (canGoNext) {
-			imageTransitionDirection = 'right';
-			currentGalleryIndex++;
-		}
-	}
-
-	function handleKeydown(e: KeyboardEvent) {
-		if (!lightboxDialog?.open) return;
-		switch (e.key) {
-			case 'Escape':
-				closeLightbox();
-				break;
-			case 'ArrowLeft':
-				e.preventDefault();
-				goToPrevImage();
-				break;
-			case 'ArrowRight':
-				e.preventDefault();
-				goToNextImage();
-				break;
-		}
-	}
-
-	function fadeScale(
-		node: Element,
-		params?: { duration?: number; delay?: number; easing?: (t: number) => number }
-	) {
-		return {
-			css: (t: number, u: number) => {
-				const fadeRet = fade(node, params);
-				const scaleRet = scale(node, { ...params, start: 0.95 });
-				return (fadeRet.css?.(t, u) ?? '') + (scaleRet.css?.(t, u) ?? '');
-			}
-		};
-	}
+	onDestroy(() => {
+		pswpInstance?.destroy();
+		pswpInstance = null;
+	});
 </script>
 
 {#if !shouldHide}
@@ -217,6 +202,7 @@
 				<source type="image/avif" srcset={avifSrcset || undefined} {sizes} />
 				<source type="image/jpeg" srcset={jpegSrcset || undefined} {sizes} />
 				<img
+					bind:this={thumbImg}
 					{src}
 					alt={image.alt ?? ''}
 					width={image.width ?? undefined}
@@ -257,95 +243,6 @@
 			</div>
 		{/if}
 	</div>
-
-	{#if hasLightbox}
-		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-		<dialog
-			bind:this={lightboxDialog}
-			class="lightbox"
-			transition:fadeScale={{ duration: 400, easing: quintOut }}
-			onclick={(e) => {
-				if (e.target === lightboxDialog) closeLightbox();
-			}}
-			onkeydown={handleKeydown}
-		>
-			<button
-				class="close-button"
-				onclick={closeLightbox}
-				aria-label="Close lightbox"
-				type="button"
-			>
-				<Icon name="x" size={32} />
-			</button>
-
-			<div class="lightbox-contents">
-				<div class="image-wrapper">
-					{#key currentGalleryIndex}
-						<picture
-							class="lightbox-picture"
-							in:fly={{
-								x: imageTransitionDirection === 'right' ? 100 : -100,
-								duration: 300,
-								easing: quintOut
-							}}
-							out:fly={{
-								x: imageTransitionDirection === 'right' ? -100 : 100,
-								duration: 300,
-								easing: quintOut
-							}}
-						>
-							<source
-								type="image/avif"
-								srcset={lightboxSrcsets.avifSrcset || undefined}
-								sizes="100vw"
-							/>
-							<source
-								type="image/jpeg"
-								srcset={lightboxSrcsets.jpegSrcset || undefined}
-								sizes="100vw"
-							/>
-							<img
-								src={currentLightboxImage?.url
-									? getMediaUrl(currentLightboxImage.url, useProxy)
-									: ''}
-								alt={currentLightboxImage?.alt ?? ''}
-								class="lightbox-image"
-								oncontextmenu={disableContextMenu ? preventContextMenu : undefined}
-							/>
-						</picture>
-					{/key}
-				</div>
-
-				{#if hasGallery && gallery}
-					<div class="gallery-counter">
-						{currentGalleryIndex + 1} / {gallery.length}
-					</div>
-				{/if}
-			</div>
-
-			{#if canGoPrev}
-				<button
-					class="nav-button nav-button--prev"
-					onclick={goToPrevImage}
-					aria-label="Previous image"
-					type="button"
-				>
-					<Icon name="chevron-left" size={48} />
-				</button>
-			{/if}
-
-			{#if canGoNext}
-				<button
-					class="nav-button nav-button--next"
-					onclick={goToNextImage}
-					aria-label="Next image"
-					type="button"
-				>
-					<Icon name="chevron-right" size={48} />
-				</button>
-			{/if}
-		</dialog>
-	{/if}
 {/if}
 
 <style>
@@ -399,175 +296,5 @@
 
 	.error-overlay {
 		background: rgba(0, 0, 0, 0.6);
-	}
-
-	dialog {
-		&.lightbox {
-			box-sizing: border-box;
-			position: fixed;
-			inset: 0;
-			border: 0;
-			width: 100vw;
-			height: 100dvh;
-			max-width: 100vw;
-			max-height: 100dvh;
-			padding: 0;
-			margin: 0;
-			overflow: hidden;
-			overscroll-behavior: contain;
-			background: rgba(0, 0, 0, 0.95);
-		}
-
-		.lightbox-contents {
-			box-sizing: border-box;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			width: 100%;
-			height: 100%;
-			min-height: 0;
-			padding: 5rem;
-			position: relative;
-			overflow: hidden;
-		}
-
-		.image-wrapper {
-			position: relative;
-			width: 100%;
-			height: 100%;
-			min-width: 0;
-			min-height: 0;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			overflow: hidden;
-		}
-
-		.lightbox-picture {
-			position: absolute;
-			inset: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			max-width: 100%;
-			max-height: 100%;
-		}
-
-		.lightbox-image {
-			display: block;
-			width: auto;
-			height: auto;
-			max-width: 100%;
-			max-height: 100%;
-			object-fit: contain;
-			cursor: default;
-		}
-	}
-
-	.close-button {
-		position: absolute;
-		top: 1rem;
-		right: 1rem;
-		z-index: 10;
-		background: rgba(255, 255, 255, 0.1);
-		border: 2px solid rgba(255, 255, 255, 0.3);
-		border-radius: 4px;
-		color: white;
-		padding: 0.5rem;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: all 0.2s ease;
-		backdrop-filter: blur(10px);
-	}
-
-	.close-button:hover {
-		background: rgba(255, 255, 255, 0.2);
-		border-color: rgba(255, 255, 255, 0.5);
-		transform: scale(1.05);
-	}
-
-	.close-button:active {
-		transform: scale(0.95);
-	}
-
-	.nav-button {
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-		z-index: 10;
-		background: rgba(255, 255, 255, 0.1);
-		border: 2px solid rgba(255, 255, 255, 0.3);
-		border-radius: 4px;
-		color: white;
-		padding: 1rem;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		transition: all 0.2s ease;
-		backdrop-filter: blur(10px);
-	}
-
-	.nav-button:hover {
-		background: rgba(255, 255, 255, 0.2);
-		border-color: rgba(255, 255, 255, 0.5);
-		transform: translateY(-50%) scale(1.05);
-	}
-
-	.nav-button:active {
-		transform: translateY(-50%) scale(0.95);
-	}
-
-	.nav-button--prev {
-		left: 1rem;
-	}
-
-	.nav-button--next {
-		right: 1rem;
-	}
-
-	.gallery-counter {
-		position: absolute;
-		bottom: 2rem;
-		left: 50%;
-		transform: translateX(-50%);
-		background: rgba(0, 0, 0, 0.7);
-		color: white;
-		padding: 0.5rem 1rem;
-		border-radius: 4px;
-		font-family: var(--font-oswald, sans-serif);
-		font-size: 0.875rem;
-		backdrop-filter: blur(10px);
-		border: 1px solid rgba(255, 255, 255, 0.2);
-	}
-
-	@media (max-width: 768px) {
-		.lightbox-contents {
-			padding: 3.5rem 1rem 3rem;
-		}
-
-		.nav-button {
-			padding: 0.75rem;
-		}
-
-		.nav-button--prev {
-			left: 0.5rem;
-		}
-
-		.nav-button--next {
-			right: 0.5rem;
-		}
-
-		.close-button {
-			top: 0.5rem;
-			right: 0.5rem;
-		}
-
-		.gallery-counter {
-			bottom: 1rem;
-			font-size: 0.75rem;
-		}
 	}
 </style>

--- a/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
+++ b/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
@@ -88,17 +88,19 @@
 		>
 			{article.title}
 		</h1>
-		{#if pubLabel || createdLabel || categoryTitle || cmsEditHref || share || article.tags?.length}
+		{#if pubLabel || createdLabel || article._status === 'draft' || categoryTitle || cmsEditHref || share || article.tags?.length}
 			<div
 				class="article-dateline"
 				style:view-transition-name={article.slug ? `article-dateline-${article.slug}` : undefined}
 			>
-				{#if pubLabel || createdLabel}
+				{#if pubLabel || createdLabel || article._status === 'draft'}
 					<div
 						class="article-meta article-meta--dates"
 						style:view-transition-name={`article-meta-${article.slug}`}
 					>
-						{#if pubLabel}
+						{#if article._status === 'draft'}
+							<span class="article-draft-badge">Draft</span>
+						{:else if pubLabel}
 							<span style:view-transition-name={`article-pub-date-${article.slug}`}>
 								Published on {pubLabel}
 							</span>
@@ -266,6 +268,16 @@
 		&:hover {
 			text-decoration: underline;
 		}
+	}
+
+	.article-draft-badge {
+		display: inline-block;
+		padding: 0.05rem 0.35rem;
+		margin-right: 0.15rem;
+		border: 1px solid #8b0000;
+		color: #8b0000;
+		font-weight: 700;
+		letter-spacing: 0.08em;
 	}
 
 	.article-share {

--- a/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
+++ b/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
@@ -52,6 +52,12 @@
 	type SidebarTab = 'information' | 'metrics' | 'shop';
 
 	let activeSidebarTab = $state<SidebarTab>('information');
+	/** When true, hide the details panel so the image fills the viewport. */
+	let infoCollapsed = $state(false);
+
+	function toggleInfoPanel() {
+		infoCollapsed = !infoCollapsed;
+	}
 
 	const sidebarTabs = $derived<SidebarTab[]>(
 		isAdmin ? ['information', 'metrics', 'shop'] : ['information', 'shop']
@@ -414,8 +420,11 @@
 </script>
 
 <div class="gallery-lightbox" style:--image-aspect-ratio={imageAspectRatio}>
-	<div class="gallery-lightbox__body">
-		<!-- Left 75%: image pane with arrows on edges, close in corner -->
+	<div
+		class="gallery-lightbox__body"
+		class:gallery-lightbox__body--info-collapsed={infoCollapsed}
+	>
+		<!-- Image pane: grows to fill when the info panel is collapsed -->
 		<div class="gallery-lightbox__image-pane">
 			<button
 				class="gallery-lightbox__backdrop"
@@ -570,8 +579,50 @@
 			<p class="gallery-lightbox__counter">{index + 1} / {total}</p>
 		</div>
 
-		<!-- Right 25%: tabbed info panel -->
-		<aside class="gallery-lightbox__info">
+		<!-- Seam handle between image and details -->
+		<button
+			class="gallery-lightbox__info-toggle"
+			class:gallery-lightbox__info-toggle--collapsed={infoCollapsed}
+			onclick={(e) => {
+				e.stopPropagation();
+				toggleInfoPanel();
+			}}
+			aria-label={infoCollapsed ? 'Show image details' : 'Hide image details'}
+			aria-expanded={!infoCollapsed}
+			aria-controls="gallery-lightbox-info"
+			type="button"
+			title={infoCollapsed ? 'Show details' : 'Hide details'}
+		>
+			<svg
+				class="gallery-lightbox__info-toggle-chevron"
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"
+			>
+				{#if infoCollapsed}
+					<polyline points="15 18 9 12 15 6"></polyline>
+				{:else}
+					<polyline points="9 18 15 12 9 6"></polyline>
+				{/if}
+			</svg>
+			<span class="gallery-lightbox__info-toggle-label">
+				{infoCollapsed ? 'Details' : 'Hide details'}
+			</span>
+		</button>
+
+		<!-- Tabbed info panel (collapsible) -->
+		<aside
+			id="gallery-lightbox-info"
+			class="gallery-lightbox__info"
+			aria-hidden={infoCollapsed}
+			inert={infoCollapsed || undefined}
+		>
 			<div
 				class="gallery-lightbox__tabs"
 				role="tablist"
@@ -854,29 +905,10 @@
 
 	.gallery-lightbox__backdrop,
 	.gallery-lightbox__close,
+	.gallery-lightbox__info-toggle,
 	.gallery-lightbox__nav,
 	.gallery-lightbox__info {
 		pointer-events: auto;
-	}
-
-	/* Left 75%: image pane */
-	.gallery-lightbox__image-pane {
-		flex: 0 0 75%;
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		min-width: 0;
-	}
-
-	.gallery-lightbox__backdrop {
-		position: absolute;
-		inset: 0;
-		z-index: 0;
-		background: transparent;
-		border: none;
-		cursor: pointer;
-		padding: 0;
 	}
 
 	.gallery-lightbox__close {
@@ -899,6 +931,78 @@
 
 	.gallery-lightbox__close:hover {
 		background: rgba(0, 0, 0, 0.6);
+	}
+
+	/* Drawer seam between image and details panel */
+	.gallery-lightbox__info-toggle {
+		flex: 0 0 2.4rem;
+		align-self: stretch;
+		z-index: 12;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.65rem;
+		margin: 0;
+		padding: 0.5rem 0;
+		border: none;
+		border-left: 1px solid var(--color-tertiary-lighter);
+		border-right: none;
+		background: var(--color-tertiary-darker);
+		color: var(--color-tertiary);
+		cursor: pointer;
+		transition:
+			background 160ms ease,
+			color 160ms ease,
+			flex-basis 220ms ease;
+	}
+
+	.gallery-lightbox__info-toggle:hover,
+	.gallery-lightbox__info-toggle:focus-visible {
+		background: color-mix(in oklch, var(--color-tertiary-darker) 80%, black);
+		color: var(--color-white-lightest);
+	}
+
+	.gallery-lightbox__info-toggle--collapsed {
+		flex-basis: 2.4rem;
+		border-left: 1px solid var(--color-tertiary-lighter);
+		color: var(--color-secondary);
+	}
+
+	.gallery-lightbox__info-toggle-chevron {
+		flex-shrink: 0;
+	}
+
+	.gallery-lightbox__info-toggle-label {
+		writing-mode: vertical-rl;
+		text-orientation: mixed;
+		font-family: var(--font-roboto, system-ui, sans-serif);
+		font-size: 0.8125rem;
+		font-weight: 500;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		line-height: 1;
+	}
+
+	/* Image pane grows when the info panel collapses */
+	.gallery-lightbox__image-pane {
+		flex: 1 1 0;
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 0;
+		transition: flex-basis 220ms ease;
+	}
+
+	.gallery-lightbox__backdrop {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		padding: 0;
 	}
 
 	.gallery-lightbox__nav {
@@ -1057,12 +1161,29 @@
 		flex-direction: column;
 		gap: 0.625rem;
 		padding: 0.875rem 1rem;
+		overflow-x: hidden;
 		overflow-y: auto;
 		background: var(--color-tertiary-darker);
-		border-left: 1px solid var(--color-tertiary-lighter);
+		border-left: none;
 		color: var(--color-white-lightest);
 		font-family: var(--font-special-elite);
-		animation: infoPanelFade 180ms ease;
+		animation: infoPaneFade 180ms ease;
+		min-width: 0;
+		transition:
+			flex-basis 220ms ease,
+			padding 220ms ease,
+			opacity 180ms ease,
+			border-color 180ms ease;
+	}
+
+	.gallery-lightbox__body--info-collapsed .gallery-lightbox__info {
+		flex-basis: 0;
+		flex-grow: 0;
+		flex-shrink: 0;
+		padding-left: 0;
+		padding-right: 0;
+		opacity: 0;
+		pointer-events: none;
 	}
 
 	.gallery-lightbox__tabs {
@@ -1361,10 +1482,45 @@
 			min-height: 50vh;
 		}
 
-		.gallery-lightbox__info {
-			flex: 0 0 auto;
+		.gallery-lightbox__info-toggle {
+			flex: 0 0 2rem;
+			flex-direction: row;
+			gap: 0.45rem;
 			border-left: none;
 			border-top: 1px solid var(--color-tertiary-lighter);
+			padding: 0.35rem 0.75rem;
+		}
+
+		.gallery-lightbox__info-toggle--collapsed {
+			flex-basis: 2.5rem;
+		}
+
+		.gallery-lightbox__info-toggle-chevron {
+			transform: rotate(90deg);
+		}
+
+		.gallery-lightbox__info-toggle-label {
+			writing-mode: horizontal-tb;
+			letter-spacing: 0.06em;
+		}
+
+		.gallery-lightbox__info {
+			flex: 0 0 auto;
+			max-height: 45vh;
+			border-top: none;
+		}
+
+		.gallery-lightbox__body--info-collapsed .gallery-lightbox__image-pane {
+			min-height: 0;
+			flex: 1 1 100%;
+		}
+
+		.gallery-lightbox__body--info-collapsed .gallery-lightbox__info {
+			flex-basis: 0;
+			max-height: 0;
+			padding-top: 0;
+			padding-bottom: 0;
+			overflow: hidden;
 		}
 	}
 
@@ -1372,6 +1528,11 @@
 		.gallery-lightbox__spinner {
 			animation: none;
 			border-top-color: rgba(255, 255, 255, 0.6);
+		}
+
+		.gallery-lightbox__image-pane,
+		.gallery-lightbox__info {
+			transition: none;
 		}
 	}
 </style>

--- a/src/lib/components/gallery/Lightbox/Lightbox.svelte
+++ b/src/lib/components/gallery/Lightbox/Lightbox.svelte
@@ -285,9 +285,9 @@
 				ontouchend={handleTouchEnd}
 			>
 				{#if content}
-					{#key currentIndex}
-						{@render content(contentArgs)}
-					{/key}
+					<!-- No {#key}: custom content (gallery) owns its own image transitions and must
+					     keep UI state (e.g. collapsed info panel) across next/prev. -->
+					{@render content(contentArgs)}
 				{:else}
 					{#key currentIndex}
 						{#if placeholderSrc && !isLoaded}

--- a/src/lib/query/client.ts
+++ b/src/lib/query/client.ts
@@ -7,6 +7,12 @@ export const SWR_STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 export const SWR_GC_TIME_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
+ * Site nav + siteMeta (`layout` query) must never leave memory or IndexedDB —
+ * they back chrome on every page and offline first paint.
+ */
+export const LAYOUT_GC_TIME_MS = Infinity;
+
+/**
  * A fresh QueryClient per SSR request / browser session. Defaults implement the
  * stale-while-revalidate behavior: cached content paints instantly, then a
  * background refetch updates the view if the data changed.
@@ -18,7 +24,8 @@ export function createQueryClient(): QueryClient {
 				staleTime: SWR_STALE_TIME_MS,
 				gcTime: SWR_GC_TIME_MS,
 				retry: 1,
-				refetchOnWindowFocus: false,
+				// Always revalidate on tab focus (ignore staleTime) so CMS edits show up on return.
+				refetchOnWindowFocus: 'always',
 				refetchOnReconnect: true,
 				// Content already shown from cache should refetch on mount when stale.
 				refetchOnMount: true

--- a/src/lib/query/queries.ts
+++ b/src/lib/query/queries.ts
@@ -14,6 +14,7 @@ import {
 } from '$lib/cache/articleCache';
 import type { LayoutCacheData } from '$lib/cache/layoutCache';
 import type { ProjectsCacheData } from '$lib/cache/projectCache';
+import { LAYOUT_GC_TIME_MS } from '$lib/query/client';
 
 async function getJson<T>(url: string): Promise<T> {
 	const res = await fetch(url);
@@ -25,8 +26,10 @@ async function getJson<T>(url: string): Promise<T> {
 
 export const queryKeys = {
 	layout: ['layout'] as const,
-	articlesList: (query: ArticlesListQuery) => ['articles', 'list', query] as const,
-	article: (slug: string) => ['article', slug] as const,
+	articlesList: (query: ArticlesListQuery, includeDrafts = false) =>
+		['articles', 'list', query, { includeDrafts }] as const,
+	article: (slug: string, includeDrafts = false) =>
+		['article', slug, { includeDrafts }] as const,
 	projects: (page: number, limit: number) => ['projects', page, limit] as const
 };
 
@@ -35,23 +38,24 @@ export function layoutQueryOptions(initialData?: LayoutCacheData | null) {
 		queryKey: queryKeys.layout,
 		queryFn: () => getJson<LayoutCacheData>('/api/layout-data'),
 		enabled: browser,
+		gcTime: LAYOUT_GC_TIME_MS,
 		placeholderData: (previousData: LayoutCacheData | undefined) => previousData,
 		refetchOnMount: false,
 		...(initialData ? { initialData, initialDataUpdatedAt: Date.now() } : {})
 	};
 }
 
-export function articlesListQueryOptions(query: ArticlesListQuery) {
+export function articlesListQueryOptions(query: ArticlesListQuery, includeDrafts = false) {
 	return {
-		queryKey: queryKeys.articlesList(query),
+		queryKey: queryKeys.articlesList(query, includeDrafts),
 		queryFn: () => getJson<ArticlesListCacheData>(buildArticlesDataUrl(query)),
 		enabled: browser
 	};
 }
 
-export function articleQueryOptions(slug: string) {
+export function articleQueryOptions(slug: string, includeDrafts = false) {
 	return {
-		queryKey: queryKeys.article(slug),
+		queryKey: queryKeys.article(slug, includeDrafts),
 		queryFn: () => getJson<ArticleCacheData>(`/api/articles/${slug}`),
 		enabled: browser
 	};

--- a/src/lib/utils/photoswipe/media-to-slide.ts
+++ b/src/lib/utils/photoswipe/media-to-slide.ts
@@ -1,0 +1,56 @@
+import type { Media } from '$lib/types/payload-types';
+import { getMediaUrl } from '$lib/utils/media-url';
+import type { SlideData } from 'photoswipe';
+
+const SIZE_KEYS = ['xlarge', 'large', 'medium', 'small', 'thumbnail'] as const;
+
+function resolveDims(img: Media): { width: number; height: number } {
+	if (img.width && img.height) {
+		return { width: img.width, height: img.height };
+	}
+	for (const key of SIZE_KEYS) {
+		const size = img.sizes?.[key];
+		if (size?.width && size?.height) {
+			return { width: size.width, height: size.height };
+		}
+	}
+	return { width: 1600, height: 1200 };
+}
+
+function thumbnailUrl(img: Media, useProxy: boolean): string | undefined {
+	const thumb = img.sizes?.thumbnail?.url ?? img.sizes?.small?.url;
+	if (thumb) return getMediaUrl(thumb, useProxy);
+	if (img.blurhash) return img.blurhash;
+	return undefined;
+}
+
+/**
+ * Map Payload Media into a PhotoSwipe slide.
+ * Uses the full original as `src` (no srcset) so zoom isn't limited to a
+ * viewport-sized derivative. `msrc` is only a lightweight open placeholder.
+ */
+export function mediaToPhotoSwipeSlide(
+	img: Media,
+	options: {
+		useProxy?: boolean;
+		/** Thumbnail element for open/close zoom animation */
+		element?: HTMLElement | null;
+		/** Set when the thumbnail uses object-fit: cover */
+		thumbCropped?: boolean;
+	} = {}
+): SlideData {
+	const useProxy = options.useProxy === true;
+	const src = img.url ? getMediaUrl(img.url, useProxy) : '';
+	const { width, height } = resolveDims(img);
+	const msrc = thumbnailUrl(img, useProxy);
+
+	return {
+		src,
+		width,
+		height,
+		alt: img.alt ?? '',
+		...(msrc ? { msrc } : {}),
+		...(options.element ? { element: options.element } : {}),
+		...(options.thumbCropped ? { thumbCropped: true } : {})
+	};
+}

--- a/src/routes/(site)/+layout.svelte
+++ b/src/routes/(site)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onNavigate } from '$app/navigation';
 	import { PersistQueryClientProvider } from '@tanstack/svelte-query-persist-client';
-	import { createQueryClient, SWR_GC_TIME_MS } from '$lib/query/client';
+	import { createQueryClient, LAYOUT_GC_TIME_MS } from '$lib/query/client';
 	import { createIdbPersister } from '$lib/query/idbPersister';
 	import { shouldPersistQuery } from '$lib/query/shouldPersistQuery';
 	import SiteChrome from './SiteChrome.svelte';
@@ -35,7 +35,8 @@
 	client={queryClient}
 	persistOptions={{
 		persister,
-		maxAge: SWR_GC_TIME_MS,
+		// Must be >= layout gcTime so nav/siteMeta survive IndexedDB restores indefinitely.
+		maxAge: LAYOUT_GC_TIME_MS,
 		// Bust caches written before article-body exclusion / shorter maxAge.
 		buster: 'v2-no-article-bodies',
 		dehydrateOptions: {

--- a/src/routes/(site)/articles/+page.svelte
+++ b/src/routes/(site)/articles/+page.svelte
@@ -9,7 +9,12 @@
 
 	const { data }: PageProps = $props();
 
-	const query = createQuery(() => articlesListQueryOptions(data.query));
+	const includeDrafts = $derived(
+		!!page.data.session?.user &&
+			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
+	);
+
+	const query = createQuery(() => articlesListQueryOptions(data.query, includeDrafts));
 
 	const articles = $derived(query.data?.articles ?? []);
 	const categories = $derived(query.data?.categories ?? []);

--- a/src/routes/(site)/articles/[slug]/+page.svelte
+++ b/src/routes/(site)/articles/[slug]/+page.svelte
@@ -13,7 +13,12 @@
 
 	const { data }: PageProps = $props();
 
-	const query = createQuery(() => articleQueryOptions(data.slug));
+	const includeDrafts = $derived(
+		!!page.data.session?.user &&
+			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
+	);
+
+	const query = createQuery(() => articleQueryOptions(data.slug, includeDrafts));
 
 	const article = $derived(query.data?.article);
 	const relatedModels = $derived(query.data?.relatedModels ?? []);

--- a/src/routes/(site)/models/+page.server.ts
+++ b/src/routes/(site)/models/+page.server.ts
@@ -1,8 +1,10 @@
+import { getMergedSessionUser, isAdminRole } from '$lib/auth/requireAdmin.server';
 import { getPayloadSDK } from '$lib/payload/sdk.server';
 import type { PageServerLoad } from './$types';
 import { normalizeModelSort, normalizeModelStatus } from './filters';
 
-export const load: PageServerLoad = async ({ fetch, request, url }) => {
+export const load: PageServerLoad = async (event) => {
+	const { fetch, request, url } = event;
 	const sdk = getPayloadSDK(fetch, request);
 
 	const manufacturer = url.searchParams.get('manufacturer')?.trim() || '';
@@ -14,39 +16,63 @@ export const load: PageServerLoad = async ({ fetch, request, url }) => {
 	const page = Number(url.searchParams.get('page')) || 1;
 	const limit = Number(url.searchParams.get('limit')) || 15;
 
+	const user = await getMergedSessionUser(event);
+	const isAdmin = isAdminRole(user);
+
+	// Non-admins cannot filter to NOT_STARTED (hidden from public listings).
+	const effectiveStatus = !isAdmin && status === 'NOT_STARTED' ? null : status;
+	const forceEmpty = !isAdmin && status === 'NOT_STARTED';
+
 	const andFilters = [
 		...(manufacturer
 			? [{ 'model_meta.kit.manufacturer.slug': { equals: manufacturer } }]
 			: []),
 		...(scale ? [{ 'model_meta.kit.scale.slug': { equals: scale } }] : []),
-		...(status ? [{ 'model_meta.status': { equals: status } }] : []),
+		...(effectiveStatus
+			? [{ 'model_meta.status': { equals: effectiveStatus } }]
+			: isAdmin
+				? []
+				: [{ 'model_meta.status': { not_equals: 'NOT_STARTED' } }]),
 		...(tag ? [{ 'model_meta.tags.slug': { equals: tag } }] : [])
 	];
 
 	const [modelsData, manufacturersData, scalesData, tagsData] = await Promise.all([
-		sdk.find({
-			collection: 'models',
-			sort,
-			limit,
-			page,
-			depth: 2,
-			select: {
-				id: true,
-				title: true,
-				createdAt: true,
-				updatedAt: true,
-				slug: true,
-				model_meta: true,
-				clockify_project: true
-			},
-			...(andFilters.length > 0
-				? {
-						where: {
-							and: andFilters as never[]
-						}
-					}
-				: {})
-		}),
+		forceEmpty
+			? Promise.resolve({
+					docs: [],
+					totalDocs: 0,
+					limit,
+					totalPages: 0,
+					page,
+					pagingCounter: 0,
+					hasPrevPage: false,
+					hasNextPage: false,
+					prevPage: null,
+					nextPage: null
+				})
+			: sdk.find({
+					collection: 'models',
+					sort,
+					limit,
+					page,
+					depth: 2,
+					select: {
+						id: true,
+						title: true,
+						createdAt: true,
+						updatedAt: true,
+						slug: true,
+						model_meta: true,
+						clockify_project: true
+					},
+					...(andFilters.length > 0
+						? {
+								where: {
+									and: andFilters as never[]
+								}
+							}
+						: {})
+				}),
 		sdk.find({
 			collection: 'manufacturers',
 			limit: 100,
@@ -74,6 +100,7 @@ export const load: PageServerLoad = async ({ fetch, request, url }) => {
 		meta,
 		manufacturers: manufacturersData.docs,
 		scales: scalesData.docs,
-		tags: tagsData.docs
+		tags: tagsData.docs,
+		isAdmin
 	};
 };

--- a/src/routes/(site)/models/+page.svelte
+++ b/src/routes/(site)/models/+page.svelte
@@ -35,11 +35,13 @@
 
 	const totalModels = $derived(meta?.totalDocs ?? models.length);
 
-	const statusOptions = [
-		{ value: 'NOT_STARTED', label: 'Not started' },
-		{ value: 'IN_PROGRESS', label: 'In progress' },
-		{ value: 'COMPLETED', label: 'Completed' }
-	] as const;
+	const statusOptions = $derived(
+		[
+			{ value: 'NOT_STARTED', label: 'Not started' },
+			{ value: 'IN_PROGRESS', label: 'In progress' },
+			{ value: 'COMPLETED', label: 'Completed' }
+		].filter((option) => data.isAdmin || option.value !== 'NOT_STARTED')
+	);
 
 	async function updateParam(key: string, value: string, resetPage = true) {
 		const url = new URL(page.url);

--- a/src/routes/(site)/models/[slug]/+page.server.ts
+++ b/src/routes/(site)/models/[slug]/+page.server.ts
@@ -1,8 +1,10 @@
+import { getMergedSessionUser, isAdminRole } from '$lib/auth/requireAdmin.server';
 import { getPayloadSDK } from '$lib/payload/sdk.server';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, request, params, url }) => {
+export const load: PageServerLoad = async (event) => {
+	const { fetch, request, params, url } = event;
 	const modelData = await getPayloadSDK(fetch, request).find({
 		collection: 'models',
 		depth: 2,
@@ -28,6 +30,12 @@ export const load: PageServerLoad = async ({ fetch, request, params, url }) => {
 
 	const doc = modelData.docs[0];
 	if (!doc) {
+		throw error(404, 'Model not found');
+	}
+
+	const user = await getMergedSessionUser(event);
+	const isAdmin = isAdminRole(user);
+	if (!isAdmin && doc.model_meta?.status === 'NOT_STARTED') {
 		throw error(404, 'Model not found');
 	}
 

--- a/src/routes/(site)/models/[slug]/+page.svelte
+++ b/src/routes/(site)/models/[slug]/+page.svelte
@@ -156,7 +156,17 @@
 						<div><strong>Year Released:</strong> {kit?.year_released}</div>
 						<div><strong>Kit Number:</strong> {kit?.kit_number}</div>
 						{#if kit?.scalemates}
-							<div><a href={kit.scalemates}>Scalemates Link</a></div>
+							<div>
+								<a
+									class="scalemates-link"
+									href={kit.scalemates}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Scalemates Link
+									<Icon name="external-link" size={12} />
+								</a>
+							</div>
 						{/if}
 						{#if model.model_meta?.tags && model.model_meta?.tags.length > 0}
 							<div>
@@ -362,6 +372,17 @@
 	.kit-note {
 		display: flex;
 		justify-content: center;
+	}
+
+	.scalemates-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3em;
+	}
+
+	.scalemates-link :global(.icon) {
+		flex-shrink: 0;
+		opacity: 0.75;
 	}
 
 	.related-section {

--- a/src/routes/api/articles-data/+server.ts
+++ b/src/routes/api/articles-data/+server.ts
@@ -1,15 +1,24 @@
+import { getMergedSessionUser, isAdminRole } from '$lib/auth/requireAdmin.server';
 import { loadArticlesListPageData } from '$lib/cache/articleListCache.server';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async (event) => {
+	const { url, fetch, request } = event;
 	const page = Number(url.searchParams.get('page')) || 1;
 	const limit = Number(url.searchParams.get('limit')) || 25;
 	const category = url.searchParams.get('category') || undefined;
 	const tag = url.searchParams.get('tag') || undefined;
 	const sort = url.searchParams.get('sort') || undefined;
 
-	const result = await loadArticlesListPageData(page, limit, category, tag, sort);
+	const user = await getMergedSessionUser(event);
+	const includeDrafts = isAdminRole(user);
+
+	const result = await loadArticlesListPageData(page, limit, category, tag, sort, {
+		includeDrafts,
+		fetch,
+		request
+	});
 
 	return json(result);
 };

--- a/src/routes/api/articles/[slug]/+server.ts
+++ b/src/routes/api/articles/[slug]/+server.ts
@@ -1,9 +1,18 @@
+import { getMergedSessionUser, isAdminRole } from '$lib/auth/requireAdmin.server';
 import { loadArticlePageData } from '$lib/cache/articleCache.server';
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params, url }) => {
-	const result = await loadArticlePageData(params.slug, url.origin);
+export const GET: RequestHandler = async (event) => {
+	const { params, url, fetch, request } = event;
+	const user = await getMergedSessionUser(event);
+	const includeDrafts = isAdminRole(user);
+
+	const result = await loadArticlePageData(params.slug, url.origin, {
+		includeDrafts,
+		fetch,
+		request
+	});
 	if (!result) {
 		throw error(404, 'Article not found');
 	}


### PR DESCRIPTION
Let admins preview draft posts and not-started models, replace article/model lightboxes with PhotoSwipe, and make the gallery details panel collapsible without covering controls via the admin dock.