### PR TITLE
v0.23.0: gallery lightbox polish, CMS edits, parks map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "www-itsmillertime-dev",
 	"private": true,
-	"version": "0.22.0",
+	"version": "0.23.0",
 	"type": "module",
 	"scripts": {
 		"dev": "pnpm run fetch-payload-types && vite dev",

--- a/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
+++ b/src/lib/components/Newspaper/NewspaperArticleContent/NewspaperArticleContent.svelte
@@ -261,13 +261,28 @@
 	}
 
 	.article-cms-edit-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.2rem 0.55rem;
+		border: 1px solid #8b0000;
+		border-radius: 3px;
+		background: transparent;
 		color: #8b0000;
 		text-decoration: none;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
+		font-size: inherit;
+		line-height: 1.2;
+		transition:
+			background 0.15s ease,
+			color 0.15s ease;
 
-		&:hover {
-			text-decoration: underline;
+		&:hover,
+		&:focus-visible {
+			background: #8b0000;
+			color: #f5f0e6;
+			text-decoration: none;
 		}
 	}
 

--- a/src/lib/components/gallery/GalleryAlbumHeader/GalleryAlbumHeader.svelte
+++ b/src/lib/components/gallery/GalleryAlbumHeader/GalleryAlbumHeader.svelte
@@ -2,7 +2,16 @@
 	import Lexical from '$lib/components/Lexical';
 	import type { GalleryAlbum, GalleryCategory, GalleryTag } from '$lib/types/payload-types';
 
-	let { gallery, imageCount }: { gallery: GalleryAlbum; imageCount: number } = $props();
+	let {
+		gallery,
+		imageCount,
+		cmsEditHref = null
+	}: {
+		gallery: GalleryAlbum;
+		imageCount: number;
+		/** Admin-only Payload edit URL; omit for non-admins / Storybook. */
+		cmsEditHref?: string | null;
+	} = $props();
 
 	const category = $derived(
 		typeof gallery.settings?.category === 'object' && gallery.settings?.category !== null
@@ -89,6 +98,18 @@
 					<span class="album-header__meta-label">Date</span>
 					<span class="album-header__meta-value">{dateFormatted}</span>
 				</div>
+			{/if}
+
+			{#if cmsEditHref}
+				<a
+					href={cmsEditHref}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="album-header__cms-edit"
+					aria-label="Edit this album in the CMS (opens in a new tab)"
+				>
+					Edit in CMS
+				</a>
 			{/if}
 
 			{#if tags.length > 0}
@@ -219,6 +240,33 @@
 		color: #333;
 		font-family: var(--font-special-elite);
 		font-size: 0.95rem;
+	}
+
+	.album-header__cms-edit {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.4rem 0.85rem;
+		border: 1px solid rgba(0, 0, 0, 0.2);
+		border-radius: 4px;
+		background: rgba(0, 0, 0, 0.06);
+		font-family: var(--font-special-elite);
+		font-size: 0.75rem;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--color-primary-darker);
+		text-decoration: none;
+		transition:
+			background 0.15s ease,
+			border-color 0.15s ease,
+			color 0.15s ease;
+	}
+
+	.album-header__cms-edit:hover,
+	.album-header__cms-edit:focus-visible {
+		background: rgba(0, 0, 0, 0.1);
+		border-color: rgba(0, 0, 0, 0.35);
+		color: #1a1a1a;
 	}
 
 	.album-header__tags {

--- a/src/lib/components/gallery/GalleryAlbumPolaroid/GalleryAlbumPolaroid.stories.svelte
+++ b/src/lib/components/gallery/GalleryAlbumPolaroid/GalleryAlbumPolaroid.stories.svelte
@@ -7,6 +7,7 @@
 	const cachedMedia: GalleryGridMedia = {
 		...storybookImageMedia,
 		isNsfw: false,
+		needsProxy: false,
 		galleryImageId: 1
 	};
 

--- a/src/lib/components/gallery/GalleryAlbumPolaroid/GalleryAlbumPolaroid.svelte
+++ b/src/lib/components/gallery/GalleryAlbumPolaroid/GalleryAlbumPolaroid.svelte
@@ -109,7 +109,7 @@
 			if (media) onClick?.(media);
 		}}
 	>
-		{#key `${displayMedia.id}-${displayMedia.url ?? ''}`}
+		{#key `${displayMedia.id}-${displayMedia.url ?? ''}-${displayMedia.needsProxy ? 'p' : 'd'}`}
 			<Polaroid
 				media={displayMedia}
 				caption={displayMedia.caption
@@ -119,7 +119,7 @@
 				clickable={false}
 				enableViewTransition={false}
 				adaptiveHeight={true}
-				{useProxy}
+				useProxy={useProxy || displayMedia.needsProxy}
 				isNsfw={displayMedia.isNsfw}
 				{priority}
 				{responsiveSizes}

--- a/src/lib/components/gallery/GalleryLandingPolaroidStack/GalleryLandingPolaroidStack.svelte
+++ b/src/lib/components/gallery/GalleryLandingPolaroidStack/GalleryLandingPolaroidStack.svelte
@@ -109,7 +109,16 @@
 	<div class="gallery-landing-polaroid__error" role="status">{loadError}</div>
 {:else}
 	{@const cover = primaryForStack}
-	{#key `${cover.id}-${cover.url ?? ''}`}
+	{@const coverNeedsProxy =
+		useProxy ||
+		Boolean(
+			cover &&
+				typeof cover === 'object' &&
+				'needsProxy' in cover &&
+				(cover as { needsProxy?: boolean }).needsProxy === true
+		)
+	}
+	{#key `${cover.id}-${cover.url ?? ''}-${coverNeedsProxy ? 'p' : 'd'}`}
 		<PolaroidStack
 			primary={cover}
 			images={[cover, ...extraImages.filter((m) => m.id !== cover.id)]}
@@ -119,7 +128,7 @@
 			{hoverFlip}
 			albumTitle={caption}
 			{albumDescription}
-			{useProxy}
+			useProxy={coverNeedsProxy}
 			{isNsfw}
 			{nsfwImageIds}
 			{albumId}

--- a/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
+++ b/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
@@ -17,6 +17,7 @@
 	import { preventContextMenu } from '$lib/utils/prevent-context-menu';
 	import { lexicalToPlainText } from '$lib/utils/lexical-to-text';
 	import { getMediaUrl, isGifMedia, isVideoMedia } from '$lib/utils/media-url';
+	import { imageZoomPan, type ImageZoomPanHandle } from '$lib/utils/image-zoom-pan';
 	import ExifIcon from '$lib/components/ExifIcon';
 	import GalleryMediaPlayer from '$lib/components/gallery/GalleryMediaPlayer';
 	import BuyButton from '$lib/components/commerce/BuyButton.svelte';
@@ -49,18 +50,39 @@
 			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
 	);
 
-	type SidebarTab = 'information' | 'metrics' | 'shop';
+	type SidebarTab = 'information' | 'admin' | 'shop';
+
+	const INFO_COLLAPSED_KEY = 'gallery-lightbox-info-collapsed';
+
+	function readInfoCollapsedPref(): boolean {
+		if (!browser) return false;
+		try {
+			return localStorage.getItem(INFO_COLLAPSED_KEY) === '1';
+		} catch {
+			return false;
+		}
+	}
+
+	function writeInfoCollapsedPref(collapsed: boolean) {
+		if (!browser) return;
+		try {
+			localStorage.setItem(INFO_COLLAPSED_KEY, collapsed ? '1' : '0');
+		} catch {
+			/* ignore quota / private mode */
+		}
+	}
 
 	let activeSidebarTab = $state<SidebarTab>('information');
 	/** When true, hide the details panel so the image fills the viewport. */
-	let infoCollapsed = $state(false);
+	let infoCollapsed = $state(readInfoCollapsedPref());
 
 	function toggleInfoPanel() {
 		infoCollapsed = !infoCollapsed;
+		writeInfoCollapsedPref(infoCollapsed);
 	}
 
 	const sidebarTabs = $derived<SidebarTab[]>(
-		isAdmin ? ['information', 'metrics', 'shop'] : ['information', 'shop']
+		isAdmin ? ['information', 'admin', 'shop'] : ['information', 'shop']
 	);
 
 	let {
@@ -97,11 +119,27 @@
 		useProxy?: boolean;
 	} = $props();
 
+	const cmsImageEditHref = $derived(
+		isAdmin && galleryImageId != null
+			? `${PUBLIC_PAYLOAD_URL}/admin/collections/gallery-images/${galleryImageId}`
+			: null
+	);
+
 	const isVideo = $derived(image ? isVideoMedia(image) : false);
+	const zoomHandle: ImageZoomPanHandle = {
+		reset: () => {},
+		isZoomed: () => false
+	};
+	let imageZoomed = $state(false);
+
 	const resolvedImageSrc = $derived(
 		imageSrc ?? (image?.url ? getMediaUrl(image.url, useProxy ?? false) : null)
 	);
 	const lightboxSrcsets = $derived(buildSrcsets(image, useProxy ?? false));
+	/** Prefer largest derivative so wheel-zoom stays sharp. */
+	const lightboxSizes = $derived(
+		image?.width != null && image.width > 0 ? `${image.width}px` : '100vw'
+	);
 
 	/** Blurhash (or parent-passed placeholder string) for underlay while full image loads */
 	const blurPlaceholder = $derived.by(() => {
@@ -142,6 +180,13 @@
 		void index;
 		void resolvedImageSrc;
 		mainImgReadyNotified = false;
+	});
+
+	$effect(() => {
+		void index;
+		void resolvedImageSrc;
+		zoomHandle.reset();
+		imageZoomed = false;
 	});
 
 	/**
@@ -520,32 +565,46 @@
 					{/if}
 					{#if resolvedImageSrc}
 						{#key index}
-							<picture class="gallery-lightbox__picture">
-								<source
-									type="image/avif"
-									srcset={lightboxSrcsets.avifSrcset || undefined}
-									sizes="100vw"
-								/>
-								<source
-									type="image/jpeg"
-									srcset={lightboxSrcsets.jpegSrcset || undefined}
-									sizes="100vw"
-								/>
-								<img
-									class="gallery-lightbox__image"
-									use:mainLightboxImage
-									src={resolvedImageSrc ?? ''}
-									alt={image?.alt ?? ''}
-									width={image?.width}
-									height={image?.height}
-									fetchpriority="high"
-									decoding="async"
-									style:opacity={mainImageLoaded ? 1 : 0}
-									onload={markMainImageReady}
-									onerror={markMainImageReady}
-									oncontextmenu={preventContextMenu}
-								/>
-							</picture>
+							<div
+								class="gallery-lightbox__zoom-layer"
+								class:gallery-lightbox__zoom-layer--zoomed={imageZoomed}
+								use:imageZoomPan={{
+									handle: zoomHandle,
+									maxScale: 5,
+									clickZoomScale: 2.5,
+									onZoomChange: (z) => {
+										imageZoomed = z;
+									}
+								}}
+							>
+								<picture class="gallery-lightbox__picture">
+									<source
+										type="image/avif"
+										srcset={lightboxSrcsets.avifSrcset || undefined}
+										sizes={lightboxSizes}
+									/>
+									<source
+										type="image/jpeg"
+										srcset={lightboxSrcsets.jpegSrcset || undefined}
+										sizes={lightboxSizes}
+									/>
+									<img
+										class="gallery-lightbox__image"
+										use:mainLightboxImage
+										src={resolvedImageSrc ?? ''}
+										alt={image?.alt ?? ''}
+										width={image?.width}
+										height={image?.height}
+										draggable="false"
+										fetchpriority="high"
+										decoding="async"
+										style:opacity={mainImageLoaded ? 1 : 0}
+										onload={markMainImageReady}
+										onerror={markMainImageReady}
+										oncontextmenu={preventContextMenu}
+									/>
+								</picture>
+							</div>
 						{/key}
 					{/if}
 				{/if}
@@ -647,15 +706,15 @@
 					<button
 						type="button"
 						class="gallery-lightbox__tab"
-						class:gallery-lightbox__tab--active={activeSidebarTab === 'metrics'}
+						class:gallery-lightbox__tab--active={activeSidebarTab === 'admin'}
 						role="tab"
-						id="gallery-lightbox-tab-metrics"
-						aria-selected={activeSidebarTab === 'metrics'}
-						aria-controls="gallery-lightbox-panel-metrics"
-						tabindex={activeSidebarTab === 'metrics' ? 0 : -1}
-						onclick={() => setSidebarTab('metrics')}
+						id="gallery-lightbox-tab-admin"
+						aria-selected={activeSidebarTab === 'admin'}
+						aria-controls="gallery-lightbox-panel-admin"
+						tabindex={activeSidebarTab === 'admin' ? 0 : -1}
+						onclick={() => setSidebarTab('admin')}
 					>
-						Metrics
+						Admin
 					</button>
 				{/if}
 				<button
@@ -739,14 +798,15 @@
 								/>
 							{/if}
 
-							{#if isAdmin && galleryImageId}
+							{#if cmsImageEditHref}
 								<span class="gallery-lightbox__toolbar-divider" aria-hidden="true"></span>
 								<a
-									href={`${PUBLIC_PAYLOAD_URL}/admin/collections/gallery-images/${galleryImageId}`}
+									href={cmsImageEditHref}
 									target="_blank"
 									rel="noopener noreferrer"
 									class="gallery-lightbox__edit-btn"
-									aria-label="Edit image in CMS"
+									aria-label="Edit image in CMS (opens in a new tab)"
+									title="Edit in CMS"
 								>
 									<svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
 										<path
@@ -831,12 +891,26 @@
 
 				{#if isAdmin}
 					<div
-						id="gallery-lightbox-panel-metrics"
+						id="gallery-lightbox-panel-admin"
 						class="gallery-lightbox__tab-panel"
 						role="tabpanel"
-						aria-labelledby="gallery-lightbox-tab-metrics"
-						hidden={activeSidebarTab !== 'metrics'}
+						aria-labelledby="gallery-lightbox-tab-admin"
+						hidden={activeSidebarTab !== 'admin'}
 					>
+						{#if cmsImageEditHref}
+							<section class="gallery-lightbox__section">
+								<h3 class="gallery-lightbox__section-title">CMS</h3>
+								<a
+									href={cmsImageEditHref}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="gallery-lightbox__cms-edit-link"
+									aria-label="Edit this image in the CMS (opens in a new tab)"
+								>
+									Edit in CMS
+								</a>
+							</section>
+						{/if}
 						<section class="gallery-lightbox__section">
 							<h3 class="gallery-lightbox__section-title">Engagement</h3>
 							<dl class="gallery-lightbox__metrics">
@@ -1052,7 +1126,7 @@
 	}
 
 	.gallery-lightbox__image-frame :global(.gallery-media-player),
-	.gallery-lightbox__image-frame .gallery-lightbox__image,
+	.gallery-lightbox__image-frame .gallery-lightbox__zoom-layer,
 	.gallery-lightbox__image-frame .gallery-lightbox__placeholder {
 		pointer-events: auto;
 	}
@@ -1128,13 +1202,34 @@
 		}
 	}
 
+	.gallery-lightbox__zoom-layer {
+		position: absolute;
+		inset: 0;
+		z-index: 3;
+		display: block;
+		width: 100%;
+		height: 100%;
+		cursor: zoom-in;
+		touch-action: none;
+		user-select: none;
+		-webkit-user-drag: none;
+	}
+
+	.gallery-lightbox__zoom-layer--zoomed {
+		cursor: grab;
+	}
+
+	.gallery-lightbox__zoom-layer--zoomed:active {
+		cursor: grabbing;
+	}
+
 	.gallery-lightbox__picture {
 		position: absolute;
 		inset: 0;
 		display: block;
 		width: 100%;
 		height: 100%;
-		z-index: 3;
+		pointer-events: none;
 		animation: imageFadeIn 180ms ease;
 	}
 
@@ -1144,6 +1239,7 @@
 		height: 100%;
 		object-fit: contain;
 		object-position: center;
+		pointer-events: none;
 		transition: opacity 300ms ease;
 	}
 
@@ -1298,6 +1394,34 @@
 		border-color: rgba(255, 255, 255, 0.28);
 		background: rgba(255, 255, 255, 0.12);
 		color: var(--color-secondary);
+	}
+
+	.gallery-lightbox__cms-edit-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.45rem 0.9rem;
+		border: 1px solid rgba(255, 255, 255, 0.22);
+		border-radius: 4px;
+		background: rgba(255, 255, 255, 0.06);
+		font-family: var(--font-roboto, system-ui, sans-serif);
+		font-size: 0.8125rem;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--color-secondary);
+		text-decoration: none;
+		transition:
+			border-color 150ms ease,
+			background 150ms ease,
+			color 150ms ease;
+	}
+
+	.gallery-lightbox__cms-edit-link:hover,
+	.gallery-lightbox__cms-edit-link:focus-visible {
+		border-color: rgba(255, 255, 255, 0.35);
+		background: rgba(255, 255, 255, 0.12);
+		color: var(--color-white-lightest);
 	}
 
 	.gallery-lightbox__section-text {

--- a/src/lib/components/gallery/Lightbox/Lightbox.svelte
+++ b/src/lib/components/gallery/Lightbox/Lightbox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import type { Media } from '$lib/types/payload-types';
-	import { getMediaUrl } from '$lib/utils/media-url';
+	import { getMediaUrl, isGifMedia, isVideoMedia } from '$lib/utils/media-url';
 
 	export type LightboxContentArgs = {
 		image: Media | undefined;
@@ -22,7 +22,7 @@
 	};
 
 	type LightboxProps = {
-		images: (Media & { galleryImageId?: number })[];
+		images: (Media & { galleryImageId?: number; needsProxy?: boolean })[];
 		totalCount?: number;
 		initialIndex?: number;
 		open?: boolean;
@@ -54,14 +54,24 @@
 	let isRequestingMore = $state(false);
 
 	const SWIPE_THRESHOLD = 50;
+	const SIZE_KEYS = ['xlarge', 'large', 'medium', 'small', 'thumbnail'] as const;
 
 	const currentImage = $derived(images[currentIndex]);
 	const hasPrevious = $derived(currentIndex > 0);
 	const hasNext = $derived(currentIndex < images.length - 1 || canLoadMore);
+	const imageUsesProxy = $derived(
+		useProxy ||
+			Boolean(
+				currentImage &&
+					typeof currentImage === 'object' &&
+					'needsProxy' in currentImage &&
+					(currentImage as { needsProxy?: boolean }).needsProxy === true
+			)
+	);
 
 	// Use original image URL to avoid AVIF/WebP artifacting in lightbox
 	const imageSrc = $derived(currentImage?.url ?? null);
-	const resolvedImageSrc = $derived(imageSrc ? getMediaUrl(imageSrc, useProxy) : null);
+	const resolvedImageSrc = $derived(imageSrc ? getMediaUrl(imageSrc, imageUsesProxy) : null);
 	const placeholderSrc = $derived(currentImage?.blurhash ?? null);
 
 	const displayTotal = $derived(totalCount ?? images.length);
@@ -73,7 +83,7 @@
 		imageSrc: resolvedImageSrc,
 		isLoaded,
 		placeholderSrc,
-		getMediaUrl: (path: string, proxy?: boolean) => getMediaUrl(path, proxy ?? useProxy),
+		getMediaUrl: (path: string, proxy?: boolean) => getMediaUrl(path, proxy ?? imageUsesProxy),
 		onImageLoad: () => (isLoaded = true),
 		onClose: close,
 		onPrevious: previous,
@@ -82,7 +92,7 @@
 		hasNext,
 		galleryImageId:
 			currentImage && 'galleryImageId' in currentImage ? currentImage.galleryImageId : undefined,
-		useProxy
+		useProxy: imageUsesProxy
 	});
 
 	const aspectRatio = $derived(
@@ -181,12 +191,64 @@
 		}
 	}
 
+	function mediaNeedsProxy(image: (Media & { needsProxy?: boolean }) | undefined): boolean {
+		return (
+			useProxy ||
+			Boolean(image && typeof image === 'object' && image.needsProxy === true)
+		);
+	}
+
+	/** Largest derivative URL for a mime (matches lightbox `<picture>` preference). */
+	function largestDerivativeUrl(image: Media, mimePrefix?: string): string | null {
+		const sizes = image.sizes;
+		if (!sizes) return null;
+		for (const key of SIZE_KEYS) {
+			const size = sizes[key];
+			if (!size?.url) continue;
+			if (mimePrefix && !(size.mimeType ?? '').startsWith(mimePrefix)) continue;
+			return size.url;
+		}
+		return null;
+	}
+
+	/**
+	 * Warm the URLs the lightbox will actually paint (srcset candidates + src),
+	 * not only the original `url` (which often misses the AVIF/JPEG cache entry).
+	 */
+	function preloadUrlsForImage(image: Media & { needsProxy?: boolean }): string[] {
+		if (isVideoMedia(image)) return [];
+
+		const proxy = mediaNeedsProxy(image);
+		const urls = new Set<string>();
+		const add = (path: string | null | undefined) => {
+			if (!path) return;
+			const resolved = getMediaUrl(path, proxy);
+			if (resolved) urls.add(resolved);
+		};
+
+		// GIFs must use the original file (derivatives are often filmstrips).
+		if (isGifMedia(image)) {
+			add(image.url);
+			return [...urls];
+		}
+
+		add(largestDerivativeUrl(image, 'image/avif'));
+		add(largestDerivativeUrl(image, 'image/jpeg'));
+		add(largestDerivativeUrl(image, 'image/webp'));
+		// Fallback when mime metadata is missing on sizes
+		add(largestDerivativeUrl(image));
+		add(image.url);
+		return [...urls];
+	}
+
 	function preloadByIndex(index: number) {
 		const image = images[index];
-		const src = image?.url;
-		if (!src) return;
-		const img = new Image();
-		img.src = getMediaUrl(src, useProxy);
+		if (!image) return;
+		for (const src of preloadUrlsForImage(image)) {
+			const img = new Image();
+			img.decoding = 'async';
+			img.src = src;
+		}
 	}
 
 	// Only preload when lightbox is open: current image + immediate neighbors.

--- a/src/lib/components/polaroid/PolaroidStack/PolaroidStack.svelte
+++ b/src/lib/components/polaroid/PolaroidStack/PolaroidStack.svelte
@@ -248,7 +248,15 @@
 					albumDescription={item.isPrimary ? albumDescription : undefined}
 					fixedAspectRatio={item.isPrimary ? primaryAspectRatio : 4 / 3}
 					responsiveSizes={polaroidResponsiveSizes}
-					{useProxy}
+					useProxy={
+						useProxy ||
+						Boolean(
+							item.media &&
+								typeof item.media === 'object' &&
+								'needsProxy' in item.media &&
+								(item.media as { needsProxy?: boolean }).needsProxy === true
+						)
+					}
 					isNsfw={isNsfw || (nsfwImageIds?.has(item.media.id) ?? false)}
 					onNavigate={item.isPrimary ? onNavigate : undefined}
 					{disableContextMenu}

--- a/src/lib/utils/gallery-access/gallery-access.server.ts
+++ b/src/lib/utils/gallery-access/gallery-access.server.ts
@@ -1,62 +1,8 @@
-export type GalleryVisibility = 'ALL' | 'AUTHENTICATED' | 'PRIVILEGED';
-
-export type GalleryAccessSettings = {
-	isNsfw?: boolean | null;
-	visibility?: GalleryVisibility | null;
-	permittedRoles?: string[] | null;
-	allowedUsers?: (number | { id?: number | null } | null)[] | null;
-};
-
-export type GalleryAccessUser = {
-	id?: number | string | null;
-	role?: string[] | null;
-	nsfwFiltering?: string | null;
-};
-
-/** Mirrors Payload gallery visibility + NSFW read access for the public site session. */
-export function canAccessGallerySettings(
-	settings: GalleryAccessSettings | null | undefined,
-	user: GalleryAccessUser | null | undefined
-): boolean {
-	if (!settings) return false;
-
-	const visibility = settings.visibility ?? 'ALL';
-	const isNsfw = settings.isNsfw === true;
-	const roles = Array.isArray(user?.role) ? user.role : [];
-	const isAdmin = roles.includes('admin');
-
-	if (isAdmin) return true;
-
-	if (!user) {
-		if (isNsfw) return false;
-		return visibility === 'ALL';
-	}
-
-	if (isNsfw && (user.nsfwFiltering ?? '').toLowerCase() === 'hide') {
-		return false;
-	}
-
-	if (visibility === 'ALL' || visibility === 'AUTHENTICATED') {
-		return true;
-	}
-
-	if (visibility !== 'PRIVILEGED') {
-		return false;
-	}
-
-	const permittedRoles = settings.permittedRoles ?? [];
-	if (permittedRoles.some((role) => roles.includes(role))) {
-		return true;
-	}
-
-	const userId = user.id;
-	if (userId == null) return false;
-
-	return (settings.allowedUsers ?? []).some((entry) => {
-		if (typeof entry === 'number') return entry === userId;
-		if (entry && typeof entry === 'object' && typeof entry.id === 'number') {
-			return entry.id === userId;
-		}
-		return false;
-	});
-}
+/** @deprecated Import from `$lib/utils/gallery-access` (shared module). Kept for existing `.server` import paths. */
+export {
+	canAccessGallerySettings,
+	mediaRequiresAuthProxy,
+	type GalleryAccessSettings,
+	type GalleryAccessUser,
+	type GalleryVisibility
+} from './gallery-access';

--- a/src/lib/utils/gallery-access/gallery-access.test.ts
+++ b/src/lib/utils/gallery-access/gallery-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canAccessGallerySettings } from './gallery-access.server';
+import { canAccessGallerySettings, mediaRequiresAuthProxy } from './gallery-access';
 
 describe('canAccessGallerySettings', () => {
 	it('allows public albums for anonymous users', () => {
@@ -32,5 +32,26 @@ describe('canAccessGallerySettings', () => {
 				{ id: 1, role: ['user'] }
 			)
 		).toBe(false);
+	});
+
+	it('allows admins for privileged albums', () => {
+		expect(
+			canAccessGallerySettings(
+				{ visibility: 'PRIVILEGED', permittedRoles: ['family'], isNsfw: false },
+				{ id: 1, role: ['admin'] }
+			)
+		).toBe(true);
+	});
+});
+
+describe('mediaRequiresAuthProxy', () => {
+	it('is false for public non-NSFW media', () => {
+		expect(mediaRequiresAuthProxy({ visibility: 'ALL', isNsfw: false })).toBe(false);
+	});
+
+	it('is true for NSFW, authenticated, or privileged media', () => {
+		expect(mediaRequiresAuthProxy({ visibility: 'ALL', isNsfw: true })).toBe(true);
+		expect(mediaRequiresAuthProxy({ visibility: 'AUTHENTICATED', isNsfw: false })).toBe(true);
+		expect(mediaRequiresAuthProxy({ visibility: 'PRIVILEGED', isNsfw: false })).toBe(true);
 	});
 });

--- a/src/lib/utils/gallery-access/gallery-access.ts
+++ b/src/lib/utils/gallery-access/gallery-access.ts
@@ -1,0 +1,75 @@
+export type GalleryVisibility = 'ALL' | 'AUTHENTICATED' | 'PRIVILEGED';
+
+export type GalleryAccessSettings = {
+	isNsfw?: boolean | null;
+	visibility?: GalleryVisibility | null;
+	permittedRoles?: string[] | null;
+	allowedUsers?: (number | { id?: number | null } | null)[] | null;
+};
+
+export type GalleryAccessUser = {
+	id?: number | string | null;
+	role?: string[] | null;
+	nsfwFiltering?: string | null;
+};
+
+/**
+ * True when Payload media bytes require an authenticated request (forward cookies via
+ * `/api/media-proxy`). Public `visibility: ALL` non-NSFW files can be loaded directly.
+ */
+export function mediaRequiresAuthProxy(
+	settings: GalleryAccessSettings | null | undefined
+): boolean {
+	if (!settings) return false;
+	if (settings.isNsfw === true) return true;
+	const visibility = settings.visibility ?? 'ALL';
+	return visibility !== 'ALL';
+}
+
+/** Mirrors Payload gallery visibility + NSFW read access for the public site session. */
+export function canAccessGallerySettings(
+	settings: GalleryAccessSettings | null | undefined,
+	user: GalleryAccessUser | null | undefined
+): boolean {
+	if (!settings) return false;
+
+	const visibility = settings.visibility ?? 'ALL';
+	const isNsfw = settings.isNsfw === true;
+	const roles = Array.isArray(user?.role) ? user.role : [];
+	const isAdmin = roles.includes('admin');
+
+	if (isAdmin) return true;
+
+	if (!user) {
+		if (isNsfw) return false;
+		return visibility === 'ALL';
+	}
+
+	if (isNsfw && (user.nsfwFiltering ?? '').toLowerCase() === 'hide') {
+		return false;
+	}
+
+	if (visibility === 'ALL' || visibility === 'AUTHENTICATED') {
+		return true;
+	}
+
+	if (visibility !== 'PRIVILEGED') {
+		return false;
+	}
+
+	const permittedRoles = settings.permittedRoles ?? [];
+	if (permittedRoles.some((role) => roles.includes(role))) {
+		return true;
+	}
+
+	const userId = user.id;
+	if (userId == null) return false;
+
+	return (settings.allowedUsers ?? []).some((entry) => {
+		if (typeof entry === 'number') return entry === userId;
+		if (entry && typeof entry === 'object' && typeof entry.id === 'number') {
+			return entry.id === userId;
+		}
+		return false;
+	});
+}

--- a/src/lib/utils/gallery-access/index.ts
+++ b/src/lib/utils/gallery-access/index.ts
@@ -1,6 +1,7 @@
 export {
 	canAccessGallerySettings,
+	mediaRequiresAuthProxy,
 	type GalleryAccessSettings,
 	type GalleryAccessUser,
 	type GalleryVisibility
-} from './gallery-access.server';
+} from './gallery-access';

--- a/src/lib/utils/gallery-image-display/gallery-image-display.test.ts
+++ b/src/lib/utils/gallery-image-display/gallery-image-display.test.ts
@@ -55,11 +55,34 @@ describe('galleryImageDocToDisplayMedia', () => {
 		expect(m?.url).toBe('/file.jpg');
 		expect(m?.galleryImageId).toBe(10);
 		expect(m?.isNsfw).toBe(false);
+		expect(m?.needsProxy).toBe(false);
 	});
 
 	it('respects album NSFW flag', () => {
 		const doc = { id: 1, url: '/x', alt: '', width: 1, height: 1, updatedAt: '', createdAt: '' };
-		expect(galleryImageDocToDisplayMedia(doc, true)?.isNsfw).toBe(true);
+		const m = galleryImageDocToDisplayMedia(doc, true);
+		expect(m?.isNsfw).toBe(true);
+		expect(m?.needsProxy).toBe(true);
+	});
+
+	it('sets needsProxy for privileged image settings in a public album', () => {
+		const doc = {
+			id: 3,
+			url: '/secret.jpg',
+			alt: '',
+			width: 1,
+			height: 1,
+			updatedAt: '',
+			createdAt: '',
+			settings: {
+				visibility: 'PRIVILEGED' as const,
+				permittedRoles: ['family' as const],
+				isNsfw: false
+			}
+		};
+		const m = galleryImageDocToDisplayMedia(doc, false);
+		expect(m?.needsProxy).toBe(true);
+		expect(m?.isNsfw).toBe(false);
 	});
 
 	it('extracts nested image media', () => {
@@ -78,5 +101,6 @@ describe('galleryImageDocToDisplayMedia', () => {
 		const m = galleryImageDocToDisplayMedia(doc, false);
 		expect(m?.url).toBe('/nested.jpg');
 		expect(m?.galleryImageId).toBe(5);
+		expect(m?.needsProxy).toBe(false);
 	});
 });

--- a/src/lib/utils/gallery-image-display/gallery-image-display.ts
+++ b/src/lib/utils/gallery-image-display/gallery-image-display.ts
@@ -1,4 +1,5 @@
 import type { GalleryImage, Media } from '$lib/types/payload-types';
+import { mediaRequiresAuthProxy } from '$lib/utils/gallery-access';
 
 /**
  * Commerce data attached to a sellable gallery image. Resolved server-side from
@@ -14,6 +15,11 @@ export type GalleryCommerce = {
 
 export type GalleryGridMedia = Media & {
 	isNsfw: boolean;
+	/**
+	 * When true, load bytes through `/api/media-proxy` even if the parent album is public
+	 * (per-image NSFW / AUTHENTICATED / PRIVILEGED settings).
+	 */
+	needsProxy: boolean;
 	galleryImageId?: number;
 	commerce?: GalleryCommerce | null;
 };
@@ -35,6 +41,7 @@ export function buildPlaceholderGalleryMedia(options: {
 	height?: number | null;
 	aspectRatioFallback?: number;
 	isNsfw?: boolean;
+	needsProxy?: boolean;
 }): GalleryGridMedia {
 	const ar = options.aspectRatioFallback ?? 3 / 4;
 	let w = typeof options.width === 'number' && options.width > 0 ? options.width : 0;
@@ -54,6 +61,7 @@ export function buildPlaceholderGalleryMedia(options: {
 		updatedAt: PLACEHOLDER_DATE,
 		createdAt: PLACEHOLDER_DATE,
 		isNsfw: options.isNsfw ?? false,
+		needsProxy: options.needsProxy ?? false,
 		galleryImageId: options.galleryImageId
 	};
 }
@@ -70,12 +78,14 @@ export function galleryImageDocToDisplayMedia(
 
 	const imageDoc = doc as Partial<GalleryImage>;
 	const docIsNsfw = imageDoc.settings?.isNsfw === true || albumIsNsfw;
+	const needsProxy = mediaRequiresAuthProxy(imageDoc.settings) || albumIsNsfw;
 	const galleryImageId = imageDoc.id;
 
 	if ('url' in imageDoc && 'id' in imageDoc) {
 		return {
 			...(imageDoc as Media),
 			isNsfw: docIsNsfw,
+			needsProxy,
 			galleryImageId,
 			commerce: readCommerce(imageDoc)
 		};
@@ -87,6 +97,7 @@ export function galleryImageDocToDisplayMedia(
 			return {
 				...(candidate as Media),
 				isNsfw: docIsNsfw,
+				needsProxy,
 				galleryImageId,
 				commerce: readCommerce(imageDoc)
 			};

--- a/src/lib/utils/image-zoom-pan.ts
+++ b/src/lib/utils/image-zoom-pan.ts
@@ -1,0 +1,379 @@
+export type ImageZoomPanHandle = {
+	reset: () => void;
+	isZoomed: () => boolean;
+};
+
+export type ImageZoomPanOptions = {
+	minScale?: number;
+	maxScale?: number;
+	/** Scale applied on a plain click when not zoomed. */
+	clickZoomScale?: number;
+	/** Optional mutable handle the action fills in (reset / isZoomed). */
+	handle?: ImageZoomPanHandle;
+	/** Fired when zoomed-in state toggles (scale > 1). */
+	onZoomChange?: (zoomed: boolean) => void;
+};
+
+type Point = { x: number; y: number };
+
+const MOVE_THRESHOLD_PX = 4;
+
+/**
+ * Svelte action: wheel / pinch / click zoom and drag-pan.
+ * Transform uses center origin: translate then scale.
+ */
+export function imageZoomPan(node: HTMLElement, options: ImageZoomPanOptions = {}) {
+	let minScale = options.minScale ?? 1;
+	let maxScale = options.maxScale ?? 5;
+	let clickZoomScale = options.clickZoomScale ?? 2.5;
+	let onZoomChange = options.onZoomChange;
+	let handle = options.handle;
+
+	let scale = 1;
+	let tx = 0;
+	let ty = 0;
+	let zoomed = false;
+
+	let pointers = new Map<number, Point>();
+	let pinchStartDist = 0;
+	let pinchStartScale = 1;
+	let dragging = false;
+	let dragOrigin: Point | null = null;
+	let panAtDragStart: Point = { x: 0, y: 0 };
+	let pointerDownAt: Point | null = null;
+	let movedDuringPointer = false;
+	let activePointerId: number | null = null;
+
+	function bindHandle() {
+		if (!handle) return;
+		handle.reset = reset;
+		handle.isZoomed = () => scale > 1.001;
+	}
+
+	function setZoomed(next: boolean) {
+		if (zoomed === next) return;
+		zoomed = next;
+		node.classList.toggle('is-zoomed', zoomed);
+		onZoomChange?.(zoomed);
+	}
+
+	function apply() {
+		node.style.transformOrigin = 'center center';
+		node.style.transform = `translate3d(${tx}px, ${ty}px, 0) scale(${scale})`;
+		node.style.willChange = scale > 1 || tx !== 0 || ty !== 0 ? 'transform' : 'auto';
+		node.style.cursor = scale > 1.001 ? (dragging ? 'grabbing' : 'grab') : 'zoom-in';
+		setZoomed(scale > 1.001);
+	}
+
+	function clampPan() {
+		if (scale <= 1.001) {
+			tx = 0;
+			ty = 0;
+			return;
+		}
+
+		const parent = node.parentElement ?? node;
+		const parentW = parent.clientWidth;
+		const parentH = parent.clientHeight;
+		const scaledW = node.offsetWidth * scale;
+		const scaledH = node.offsetHeight * scale;
+		const maxX = Math.max(0, (scaledW - parentW) / 2);
+		const maxY = Math.max(0, (scaledH - parentH) / 2);
+		tx = Math.min(maxX, Math.max(-maxX, tx));
+		ty = Math.min(maxY, Math.max(-maxY, ty));
+	}
+
+	/** Zoom toward a client point; keeps that screen point stable. */
+	function zoomAt(clientX: number, clientY: number, nextScale: number) {
+		// Use the untransformed frame center (parent), not the scaled node's bounding box.
+		const parent = node.parentElement ?? node;
+		const parentRect = parent.getBoundingClientRect();
+		const centerX = parentRect.left + parentRect.width / 2;
+		const centerY = parentRect.top + parentRect.height / 2;
+		const ox = clientX - centerX;
+		const oy = clientY - centerY;
+
+		const prev = Math.max(scale, 0.0001);
+		const clamped = Math.min(maxScale, Math.max(minScale, nextScale));
+		if (Math.abs(clamped - prev) < 0.0001) {
+			if (clamped <= minScale) {
+				tx = 0;
+				ty = 0;
+				scale = minScale;
+				apply();
+			}
+			return;
+		}
+
+		const localX = (ox - tx) / prev;
+		const localY = (oy - ty) / prev;
+
+		scale = clamped;
+		if (scale <= minScale) {
+			scale = minScale;
+			tx = 0;
+			ty = 0;
+		} else {
+			tx = ox - localX * scale;
+			ty = oy - localY * scale;
+			clampPan();
+		}
+		apply();
+	}
+
+	function reset() {
+		scale = minScale;
+		tx = 0;
+		ty = 0;
+		dragging = false;
+		dragOrigin = null;
+		pointerDownAt = null;
+		activePointerId = null;
+		movedDuringPointer = false;
+		pointers.clear();
+		unpinWindowDrag();
+		apply();
+	}
+
+	function onWheel(e: WheelEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+
+		let delta = -e.deltaY;
+		if (e.deltaMode === 1) delta *= 16;
+		else if (e.deltaMode === 2) delta *= 40;
+
+		const factor = Math.exp(delta * 0.00175);
+		zoomAt(e.clientX, e.clientY, scale * factor);
+	}
+
+	function pointerCount() {
+		return pointers.size;
+	}
+
+	function pinchDistance(): number {
+		const pts = [...pointers.values()];
+		if (pts.length < 2) return 0;
+		return Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+	}
+
+	function pinchCenter(): Point {
+		const pts = [...pointers.values()];
+		return { x: (pts[0].x + pts[1].x) / 2, y: (pts[0].y + pts[1].y) / 2 };
+	}
+
+	function unpinWindowDrag() {
+		window.removeEventListener('pointermove', onWindowPointerMove);
+		window.removeEventListener('pointerup', onWindowPointerUp);
+		window.removeEventListener('pointercancel', onWindowPointerUp);
+	}
+
+	function pinWindowDrag() {
+		unpinWindowDrag();
+		window.addEventListener('pointermove', onWindowPointerMove);
+		window.addEventListener('pointerup', onWindowPointerUp);
+		window.addEventListener('pointercancel', onWindowPointerUp);
+	}
+
+	function onWindowPointerMove(e: PointerEvent) {
+		if (activePointerId != null && e.pointerId !== activePointerId) return;
+		if (!pointerDownAt && !dragOrigin) return;
+
+		const origin = dragOrigin ?? pointerDownAt!;
+		const dx = e.clientX - origin.x;
+		const dy = e.clientY - origin.y;
+		if (Math.hypot(dx, dy) > MOVE_THRESHOLD_PX) movedDuringPointer = true;
+
+		if (!dragging || !dragOrigin) return;
+
+		e.preventDefault();
+		tx = panAtDragStart.x + dx;
+		ty = panAtDragStart.y + dy;
+		clampPan();
+		apply();
+	}
+
+	function onWindowPointerUp(e: PointerEvent) {
+		if (activePointerId != null && e.pointerId !== activePointerId) return;
+
+		const wasClick = !movedDuringPointer && pointerDownAt != null;
+		const clickX = pointerDownAt?.x ?? e.clientX;
+		const clickY = pointerDownAt?.y ?? e.clientY;
+
+		dragging = false;
+		dragOrigin = null;
+		activePointerId = null;
+		unpinWindowDrag();
+		pointers.delete(e.pointerId);
+
+		// Click while showing zoom-in cursor → zoom in toward click.
+		if (wasClick && scale <= 1.001) {
+			zoomAt(clickX, clickY, Math.min(maxScale, clickZoomScale));
+		} else {
+			apply();
+		}
+
+		pointerDownAt = null;
+		movedDuringPointer = false;
+	}
+
+	function onPointerDown(e: PointerEvent) {
+		if (e.pointerType === 'mouse' && e.button !== 0) return;
+		e.stopPropagation();
+
+		try {
+			node.setPointerCapture(e.pointerId);
+		} catch {
+			/* ignore */
+		}
+
+		pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+		movedDuringPointer = false;
+		pointerDownAt = { x: e.clientX, y: e.clientY };
+
+		if (pointerCount() === 2) {
+			dragging = false;
+			dragOrigin = null;
+			activePointerId = null;
+			unpinWindowDrag();
+			pinchStartDist = pinchDistance();
+			pinchStartScale = scale;
+			return;
+		}
+
+		// Start a potential pan (or click-to-zoom if never moved).
+		activePointerId = e.pointerId;
+		if (scale > 1.001) {
+			dragging = true;
+			dragOrigin = { x: e.clientX, y: e.clientY };
+			panAtDragStart = { x: tx, y: ty };
+			pinWindowDrag();
+			apply();
+		} else {
+			// Still track pointer on window so a click (no move) can zoom in.
+			dragging = false;
+			dragOrigin = { x: e.clientX, y: e.clientY };
+			panAtDragStart = { x: tx, y: ty };
+			pinWindowDrag();
+		}
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (!pointers.has(e.pointerId)) return;
+		pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+		if (pointerCount() === 2 && pinchStartDist > 0) {
+			e.preventDefault();
+			e.stopPropagation();
+			movedDuringPointer = true;
+			const dist = pinchDistance();
+			const center = pinchCenter();
+			zoomAt(center.x, center.y, pinchStartScale * (dist / pinchStartDist));
+		}
+		// Single-pointer pan is handled on window while captured via pinWindowDrag.
+	}
+
+	function onPointerUp(e: PointerEvent) {
+		pointers.delete(e.pointerId);
+		if (pointerCount() < 2) pinchStartDist = 0;
+
+		// Window handler owns click/pan end when it was the active pointer.
+		if (e.pointerId === activePointerId) return;
+
+		if (pointerCount() === 1 && scale > 1.001) {
+			const remainingId = [...pointers.keys()][0];
+			const remaining = pointers.get(remainingId)!;
+			activePointerId = remainingId;
+			dragging = true;
+			dragOrigin = { x: remaining.x, y: remaining.y };
+			panAtDragStart = { x: tx, y: ty };
+			pinWindowDrag();
+		}
+	}
+
+	function onDblClick(e: MouseEvent) {
+		// Single-click already zooms in; dblclick toggles reset when zoomed.
+		e.preventDefault();
+		e.stopPropagation();
+		if (scale > 1.05) reset();
+	}
+
+	function onTouchStart(e: TouchEvent) {
+		if (scale > 1 || e.touches.length > 1) e.stopPropagation();
+	}
+
+	function onTouchMove(e: TouchEvent) {
+		if (scale > 1 || e.touches.length > 1) {
+			e.stopPropagation();
+			if (e.cancelable) e.preventDefault();
+		}
+	}
+
+	function onTouchEnd(e: TouchEvent) {
+		if (scale > 1 || movedDuringPointer) e.stopPropagation();
+	}
+
+	function onKeyDown(e: KeyboardEvent) {
+		if (e.key !== 'Escape' || scale <= 1.001) return;
+		e.preventDefault();
+		e.stopImmediatePropagation();
+		reset();
+	}
+
+	node.style.touchAction = 'none';
+	node.style.userSelect = 'none';
+	;(node.style as CSSStyleDeclaration & { webkitUserDrag?: string }).webkitUserDrag = 'none';
+	bindHandle();
+	apply();
+
+	node.addEventListener('wheel', onWheel, { passive: false });
+	node.addEventListener('pointerdown', onPointerDown);
+	node.addEventListener('pointermove', onPointerMove);
+	node.addEventListener('pointerup', onPointerUp);
+	node.addEventListener('pointercancel', onPointerUp);
+	node.addEventListener('dblclick', onDblClick);
+	node.addEventListener('touchstart', onTouchStart, { passive: true });
+	node.addEventListener('touchmove', onTouchMove, { passive: false });
+	node.addEventListener('touchend', onTouchEnd, { passive: true });
+	window.addEventListener('keydown', onKeyDown, true);
+
+	return {
+		update(next: ImageZoomPanOptions = {}) {
+			minScale = next.minScale ?? 1;
+			maxScale = next.maxScale ?? 5;
+			clickZoomScale = next.clickZoomScale ?? 2.5;
+			onZoomChange = next.onZoomChange;
+			handle = next.handle;
+			bindHandle();
+			if (scale < minScale || scale > maxScale) {
+				scale = Math.min(maxScale, Math.max(minScale, scale));
+				clampPan();
+				apply();
+			}
+		},
+		destroy() {
+			unpinWindowDrag();
+			node.removeEventListener('wheel', onWheel);
+			node.removeEventListener('pointerdown', onPointerDown);
+			node.removeEventListener('pointermove', onPointerMove);
+			node.removeEventListener('pointerup', onPointerUp);
+			node.removeEventListener('pointercancel', onPointerUp);
+			node.removeEventListener('dblclick', onDblClick);
+			node.removeEventListener('touchstart', onTouchStart);
+			node.removeEventListener('touchmove', onTouchMove);
+			node.removeEventListener('touchend', onTouchEnd);
+			window.removeEventListener('keydown', onKeyDown, true);
+			node.style.transform = '';
+			node.style.transformOrigin = '';
+			node.style.willChange = '';
+			node.style.cursor = '';
+			node.style.touchAction = '';
+			node.style.userSelect = '';
+			node.classList.remove('is-zoomed');
+			if (handle) {
+				handle.reset = () => {};
+				handle.isZoomed = () => false;
+			}
+		}
+	};
+}

--- a/src/routes/(site)/galleries/+page.svelte
+++ b/src/routes/(site)/galleries/+page.svelte
@@ -179,6 +179,7 @@
 
 	function isImageNsfw(doc: unknown): boolean {
 		if (typeof doc !== 'object' || doc === null) return false;
+		if ('isNsfw' in doc && (doc as { isNsfw?: boolean }).isNsfw === true) return true;
 		const settings = (doc as { settings?: { isNsfw?: boolean } }).settings;
 		return settings?.isNsfw === true;
 	}

--- a/src/routes/(site)/galleries/[slug]/+page.svelte
+++ b/src/routes/(site)/galleries/[slug]/+page.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { invalidateAll, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
+	import { PUBLIC_PAYLOAD_URL } from '$env/static/public';
 	import Masonry from 'svelte-bricks';
 	import Panel from '$lib/components/Panel';
 	import GalleryAlbumHeader from '$lib/components/gallery/GalleryAlbumHeader';
@@ -26,6 +27,15 @@
 	const nsfwPref = $derived((page.data.session?.user?.nsfwFiltering ?? '').toLowerCase());
 	const shouldHideAlbum = $derived(albumIsNsfw && nsfwPref === 'hide');
 	const isDirectLinkEntry = $derived(data.selectedGalleryImageId != null);
+	const isAdmin = $derived(
+		!!page.data.session?.user &&
+			(page.data.session?.user?.role as string[] | undefined)?.includes('admin')
+	);
+	const albumCmsEditHref = $derived(
+		isAdmin && data.gallery.id != null
+			? `${PUBLIC_PAYLOAD_URL}/admin/collections/gallery-albums/${data.gallery.id}`
+			: null
+	);
 
 	type ImageSlot = {
 		id: number;
@@ -223,6 +233,31 @@
 		slotFetchDone = { ...slotFetchDone, [galleryImageId]: true };
 	}
 
+	/** While lightbox is open, resolve ±1 slot media so next/prev are in `galleryImages` and can preload. */
+	$effect(() => {
+		if (!browser || !lightboxOpen || pinnedLightboxFileMediaId == null) return;
+
+		const currentId = pinnedLightboxFileMediaId;
+		const slotIdx = visibleSlots.findIndex((s) => s.id === currentId);
+		if (slotIdx === -1) return;
+
+		const neighborIds = [visibleSlots[slotIdx - 1]?.id, visibleSlots[slotIdx + 1]?.id].filter(
+			(id): id is number => typeof id === 'number'
+		);
+
+		for (const id of neighborIds) {
+			if (slotMedia[id]) continue;
+			void fetchGalleryImageFullForPolaroid(id, albumIsNsfw).then((media) => {
+				if (media) injectResolvedMedia(media);
+			});
+		}
+
+		// Approaching the end of known slots — page in more ids for continuous next.
+		if (hasNextPage && !isLoadingMore && slotIdx >= visibleSlots.length - 2) {
+			void loadNextImagePage();
+		}
+	});
+
 	// Seed first page from server when the album changes only. Do not clear slotMedia on
 	// arbitrary data refreshes or Masonry-driven rerenders — that was wiping resolved polaroids.
 	$effect(() => {
@@ -308,6 +343,7 @@
 		<GalleryAlbumHeader
 			gallery={data.gallery as unknown as GalleryAlbum}
 			imageCount={totalImageCount}
+			cmsEditHref={albumCmsEditHref}
 		/>
 
 		<div class="gallery-grid">

--- a/src/routes/(site)/models/[slug]/+page.svelte
+++ b/src/routes/(site)/models/[slug]/+page.svelte
@@ -372,16 +372,30 @@
 	}
 
 	.cms-edit-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.35rem 0.75rem;
+		border: 1px solid var(--color-primary-darker);
+		border-radius: 4px;
+		background: transparent;
 		font-family: var(--font-oswald);
 		font-size: var(--fs-xs);
 		font-weight: 600;
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
-		text-decoration: underline;
+		text-decoration: none;
 		color: var(--color-primary-darker);
+		transition:
+			background 0.15s ease,
+			border-color 0.15s ease,
+			color 0.15s ease;
 
-		&:hover {
-			color: var(--color-secondary);
+		&:hover,
+		&:focus-visible {
+			background: var(--color-primary-darker);
+			border-color: var(--color-primary-darker);
+			color: var(--color-white-lightest, #fff);
 		}
 	}
 

--- a/src/routes/(site)/parks-and-hikes/+page.svelte
+++ b/src/routes/(site)/parks-and-hikes/+page.svelte
@@ -2,36 +2,114 @@
 	import { onMount } from 'svelte';
 	import * as maplibregl from 'maplibre-gl';
 	import 'maplibre-gl/dist/maplibre-gl.css';
-	import '@fortawesome/fontawesome-free/css/all.min.css';
 	import type { PageData } from './$types';
+	import type { GalleryAlbum, MapMarker } from '$lib/types/payload-types';
 
 	let { data }: { data: PageData } = $props();
 	let mapContainer: HTMLDivElement;
 
+	const placeCount = $derived(data.mapMarkers.length);
+	const totalVisits = $derived(
+		data.mapMarkers.reduce((sum, m) => sum + (m.visits ?? 0), 0)
+	);
+	const ratedMarkers = $derived(
+		data.mapMarkers.filter((m) => m.rating != null && !Number.isNaN(m.rating))
+	);
+	const avgRating = $derived(
+		ratedMarkers.length
+			? ratedMarkers.reduce((sum, m) => sum + (m.rating ?? 0), 0) / ratedMarkers.length
+			: null
+	);
+	const linkedCount = $derived(
+		data.mapMarkers.filter((m) =>
+			m.links?.some((link) => {
+				if (link.url) return true;
+				if (link.album && typeof link.album.value === 'object') {
+					return Boolean((link.album.value as GalleryAlbum).slug);
+				}
+				return false;
+			})
+		).length
+	);
+	const avgRatingLabel = $derived(
+		avgRating != null ? (Math.round(avgRating * 10) / 10).toFixed(1) : null
+	);
+	const topRated = $derived.by(() => {
+		let best: MapMarker | null = null;
+		for (const m of data.mapMarkers) {
+			if (m.rating == null) continue;
+			if (!best || (best.rating ?? 0) < m.rating) best = m;
+		}
+		return best;
+	});
+
+	function escapeHtml(value: string): string {
+		return value
+			.replaceAll('&', '&amp;')
+			.replaceAll('<', '&lt;')
+			.replaceAll('>', '&gt;')
+			.replaceAll('"', '&quot;')
+			.replaceAll("'", '&#39;');
+	}
+
 	function generateStars(rating: number | null | undefined): string {
-		if (!rating) return '';
+		if (rating == null || Number.isNaN(rating)) return '';
+		const full = Math.floor(rating);
+		const half = rating % 1 >= 0.5;
+		const empty = Math.max(0, 5 - full - (half ? 1 : 0));
+		return `${'★'.repeat(full)}${half ? '½' : ''}${'☆'.repeat(empty)}`;
+	}
 
-		const fullStars = Math.floor(rating);
-		const hasHalf = rating % 1 >= 0.5;
-		const emptyStars = 5 - fullStars - (hasHalf ? 1 : 0);
+	function buildLinksHtml(marker: MapMarker): string {
+		if (!marker.links?.length) return '';
 
-		let stars = '';
-		for (let i = 0; i < fullStars; i++) {
-			stars += '<i class="fa-solid fa-star"></i>';
-		}
-		if (hasHalf) {
-			stars += '<i class="fa-solid fa-star-half-stroke"></i>';
-		}
-		for (let i = 0; i < emptyStars; i++) {
-			stars += '<i class="fa-regular fa-star"></i>';
-		}
+		const links = marker.links
+			.map((link) => {
+				if (link.url) {
+					return `<a class="trail-popup__link" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(link.title)}</a>`;
+				}
+				if (link.album) {
+					const album =
+						typeof link.album.value === 'object' ? (link.album.value as GalleryAlbum) : null;
+					if (album?.slug) {
+						return `<a class="trail-popup__link" href="/galleries/${escapeHtml(album.slug)}">${escapeHtml(link.title)}</a>`;
+					}
+				}
+				return '';
+			})
+			.filter(Boolean);
 
-		return stars;
+		if (!links.length) return '';
+		return `<div class="trail-popup__links">${links.join('')}</div>`;
+	}
+
+	function createPinElement(title: string): HTMLButtonElement {
+		const el = document.createElement('button');
+		el.type = 'button';
+		el.className = 'trail-pin';
+		el.setAttribute('aria-label', `${title} — open details`);
+		// Keep transforms off this root — MapLibre positions markers via `transform`.
+		// viewBox tip sits on y=40 so anchor:"bottom" lands on the true point.
+		el.innerHTML = `
+			<span class="trail-pin__lift">
+				<svg class="trail-pin__glyph" viewBox="0 0 36 40" width="36" height="40" aria-hidden="true">
+					<path
+						class="trail-pin__body"
+						d="M18 39.75C18 39.75 5.25 24.2 5.25 14.4 5.25 7.35 11 1.75 18 1.75s12.75 5.6 12.75 12.65C30.75 24.2 18 39.75 18 39.75Z"
+					/>
+					<circle class="trail-pin__rim" cx="18" cy="14.4" r="7" />
+					<circle class="trail-pin__face" cx="18" cy="14.4" r="5" />
+					<circle class="trail-pin__glint" cx="15.9" cy="12.3" r="1.2" />
+				</svg>
+			</span>
+		`;
+		return el;
 	}
 
 	onMount(() => {
 		const map = new maplibregl.Map({
 			container: mapContainer,
+			// Raster OSM — same approach that worked before (vector + canvas filters were glitchy).
 			style: {
 				version: 8,
 				sources: {
@@ -40,7 +118,7 @@
 						tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
 						tileSize: 256,
 						attribution:
-							'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+							'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 					}
 				},
 				layers: [
@@ -53,110 +131,521 @@
 					}
 				]
 			},
-			center: [-86.2384, 41.703], // Notre Dame, South Bend, Indiana
-			zoom: 7
+			center: [-86.2384, 41.703],
+			zoom: 7,
+			attributionControl: { compact: true }
 		});
 
-		// Add markers to the map
-		data.mapMarkers.forEach((marker) => {
-			const linksHTML =
-				marker.links && marker.links.length > 0
-					? `<div class="popup-links">
-						${marker.links
-							.map((link) => {
-								// Handle external URL
-								if (link.url) {
-									return `<a href="${link.url}" target="_blank" rel="noopener noreferrer">${link.title}</a>`;
-								}
-								// Handle gallery album link
-								if (link.album) {
-									const album = typeof link.album.value === 'object' ? link.album.value : null;
-									if (album && album.slug) {
-										return `<a href="/galleries/${album.slug}">${link.title}</a>`;
-									}
-								}
-								return '';
-							})
-							.filter(Boolean)
-							.join('')}
-					</div>`
-					: '';
+		map.addControl(new maplibregl.NavigationControl({ showCompass: true }), 'top-right');
 
+		const resizeMap = () => map.resize();
+		requestAnimationFrame(resizeMap);
+		const ro =
+			typeof ResizeObserver !== 'undefined' ? new ResizeObserver(resizeMap) : null;
+		ro?.observe(mapContainer);
+
+		for (const marker of data.mapMarkers) {
 			const popupContent = `
-				<div class="marker-popup">
-					<div class="popup-title">${marker.title}</div>
-					${marker.visits ? `<div class="popup-visits">Visits: ${marker.visits}</div>` : ''}
-					${marker.rating ? `<div class="popup-rating">${generateStars(marker.rating)}</div>` : ''}
-					${linksHTML}
+				<div class="trail-popup">
+					<div class="trail-popup__rule" aria-hidden="true"></div>
+					<div class="trail-popup__title">${escapeHtml(marker.title)}</div>
+					${
+						marker.visits
+							? `<div class="trail-popup__meta">Visits logged: <span>${marker.visits}</span></div>`
+							: ''
+					}
+					${
+						marker.rating
+							? `<div class="trail-popup__rating" aria-label="Rating ${marker.rating} of 5">${generateStars(marker.rating)}</div>`
+							: ''
+					}
+					${buildLinksHtml(marker)}
+					<div class="trail-popup__rule trail-popup__rule--bottom" aria-hidden="true"></div>
 				</div>
 			`;
 
-			const popup = new maplibregl.Popup({ offset: 25 }).setHTML(popupContent);
+			const popup = new maplibregl.Popup({
+				offset: 28,
+				className: 'trail-popup-shell',
+				maxWidth: '260px',
+				closeButton: true,
+				closeOnClick: true
+			}).setHTML(popupContent);
 
-			new maplibregl.Marker().setLngLat(marker.location).setPopup(popup).addTo(map);
-		});
+			new maplibregl.Marker({
+				element: createPinElement(marker.title),
+				anchor: 'bottom'
+			})
+				.setLngLat(marker.location)
+				.setPopup(popup)
+				.addTo(map);
+		}
 
 		return () => {
+			ro?.disconnect();
 			map.remove();
 		};
 	});
 </script>
 
-<div class="map-container" bind:this={mapContainer}></div>
+<section class="field-map">
+	<div class="field-map__case">
+		<div class="field-map__frame">
+			<div class="field-map__map" bind:this={mapContainer}></div>
+			<div class="field-map__vignette" aria-hidden="true"></div>
+		</div>
+		<p class="field-map__caption">Tap a pin for visits, rating, and gallery links.</p>
+	</div>
+
+	<!-- REVERT BASELINE: topo-legend plate look (walnut frame + kraft inset + crimson title) -->
+	<header class="field-map__plate">
+		<div class="field-map__plate-inner">
+			<p class="field-map__kicker">Trail ledger</p>
+			<div class="field-map__plate-rule" aria-hidden="true"></div>
+			<h1 class="field-map__title">Parks &amp; Hikes</h1>
+			<div class="field-map__plate-rule" aria-hidden="true"></div>
+			<p class="field-map__lede">
+				Pinned stops from the road atlas — visited, rated, and linked.
+			</p>
+
+			{#if placeCount > 0}
+				<ul class="field-map__stats">
+					<li>
+						<span class="field-map__stat-value">{placeCount}</span>
+						<span class="field-map__stat-label">{placeCount === 1 ? 'place' : 'places'}</span>
+					</li>
+					{#if totalVisits > 0}
+						<li>
+							<span class="field-map__stat-value">{totalVisits}</span>
+							<span class="field-map__stat-label">{totalVisits === 1 ? 'visit' : 'visits'}</span>
+						</li>
+					{/if}
+					{#if avgRatingLabel}
+						<li>
+							<span class="field-map__stat-value">{avgRatingLabel}</span>
+							<span class="field-map__stat-label">avg rating</span>
+						</li>
+					{/if}
+					{#if linkedCount > 0}
+						<li>
+							<span class="field-map__stat-value">{linkedCount}</span>
+							<span class="field-map__stat-label">linked</span>
+						</li>
+					{/if}
+				</ul>
+			{/if}
+
+			{#if topRated}
+				<p class="field-map__footnote">
+					Highest mark: <span>{topRated.title}</span>
+					{#if topRated.rating != null}
+						({generateStars(topRated.rating)})
+					{/if}
+				</p>
+			{/if}
+		</div>
+	</header>
+</section>
 
 <style>
-	.map-container {
-		width: 100%;
-		height: 600px;
+	.field-map {
+		--trail-ink: #3a3228;
+		--trail-paper: #efe6d4;
+		--trail-paper-deep: #e4d7be;
+		--trail-rule: #8a7355;
+		--trail-pin: #8b2e24;
+		--trail-pin-deep: #5c1c16;
+		--trail-brass: #b8923c;
+		--trail-brass-light: #d4b56a;
+		margin: 0 auto;
+		padding: 1.5rem 0 3rem;
 	}
 
-	:global(.marker-popup) {
-		font-family: var(--font-special-elite);
-		line-height: 1.6;
-		min-width: 200px;
+	.field-map__plate {
+		max-width: 48rem;
+		margin: 1.5rem auto 0;
+		padding: 0.4rem;
+		background: #5c4632;
+		border: 3px double #c4a574;
+		box-shadow:
+			0 0 0 1px #3d2e20,
+			0 12px 28px rgba(40, 28, 12, 0.28);
+	}
+
+	.field-map__plate-inner {
 		text-align: center;
+		padding: 1.15rem 1.35rem 1.35rem;
+		background:
+			linear-gradient(180deg, rgba(255, 236, 210, 0.14), transparent 42%),
+			linear-gradient(180deg, #cbb089 0%, #b89a72 100%);
+		border: 1px solid rgba(45, 32, 20, 0.35);
 	}
 
-	:global(.popup-title) {
-		font-weight: bold;
-		font-size: var(--fs-xs);
-		color: var(--color-primary-darker);
-		margin-bottom: 0.5rem;
+	@media (max-width: 720px) {
+		.field-map__plate {
+			margin-left: var(--side-margins);
+			margin-right: var(--side-margins);
+		}
 	}
 
-	:global(.popup-visits) {
-		font-size: var(--fs-xs);
-		color: var(--color-tertiary-darker);
+	.field-map__kicker {
+		margin: 0;
+		font-family: var(--font-special-elite);
+		font-size: 0.72rem;
+		letter-spacing: 0.28em;
+		text-transform: uppercase;
+		color: #6b4423;
+	}
+
+	.field-map__plate-rule {
+		height: 1px;
+		margin: 0.65rem auto;
+		max-width: 14rem;
+		background: repeating-linear-gradient(
+			90deg,
+			#6b4423 0 5px,
+			transparent 5px 9px
+		);
+		opacity: 0.55;
+	}
+
+	.field-map__title {
+		margin: 0;
+		font-family: var(--font-crimson-text);
+		font-size: var(--fs-m);
+		font-weight: 600;
+		font-style: italic;
+		letter-spacing: 0.02em;
+		line-height: 1.15;
+		color: #2a1c12;
+	}
+
+	.field-map__lede {
+		margin: 0 auto;
+		max-width: 28rem;
+		font-family: var(--font-special-elite);
+		font-size: 0.8rem;
+		line-height: 1.55;
+		color: #5a4330;
+	}
+
+	.field-map__stats {
+		list-style: none;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.85rem 1.35rem;
+		margin: 1rem 0 0;
+		padding: 0.85rem 0 0;
+		border-top: 1px solid rgba(107, 68, 35, 0.28);
+	}
+
+	.field-map__stats li {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.15rem;
+		min-width: 4.25rem;
+	}
+
+	.field-map__stat-value {
+		font-family: var(--font-crimson-text);
+		font-size: 1.45rem;
+		font-weight: 600;
+		font-style: italic;
+		line-height: 1;
+		color: #2a1c12;
+	}
+
+	.field-map__stat-label {
+		font-family: var(--font-special-elite);
+		font-size: 0.65rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: #6b4423;
+	}
+
+	.field-map__footnote {
+		margin: 0.85rem 0 0;
+		font-family: var(--font-special-elite);
+		font-size: 0.72rem;
+		letter-spacing: 0.03em;
+		color: #5a4330;
+	}
+
+	.field-map__footnote span {
+		color: #2a1c12;
+	}
+
+	.field-map__case {
+		position: relative;
+		width: 100%;
+		max-width: 1280px;
+		margin: 0 auto;
+		padding: 0 var(--side-margins);
+		box-sizing: border-box;
+	}
+
+	.field-map__frame {
+		position: relative;
+		width: 100%;
+		border: 3px double color-mix(in oklab, var(--trail-rule) 70%, var(--trail-ink));
+		background: var(--trail-paper-deep);
+		padding: 0.55rem;
+		box-shadow:
+			0 0 0 1px rgba(58, 50, 40, 0.25),
+			0 14px 36px rgba(35, 24, 10, 0.28),
+			inset 0 0 0 1px rgba(255, 248, 230, 0.35);
+	}
+
+	.field-map__map {
+		position: relative;
+		width: 100%;
+		height: min(82vh, 820px);
+		min-height: 560px;
+		border: 1px solid rgba(58, 50, 40, 0.35);
+		isolation: isolate;
+	}
+
+	/* Vintage wash over tiles — never filter the WebGL canvas (breaks MapLibre). */
+	.field-map__map::after {
+		content: '';
+		pointer-events: none;
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background: rgba(180, 140, 80, 0.18);
+		mix-blend-mode: multiply;
+	}
+
+	.field-map__vignette {
+		pointer-events: none;
+		position: absolute;
+		inset: 0.55rem;
+		z-index: 1;
+		box-shadow: inset 0 0 64px rgba(42, 30, 14, 0.22);
+	}
+
+	.field-map__map :global(.maplibregl-canvas-container) {
+		z-index: 0;
+	}
+
+	.field-map__map :global(.maplibregl-marker),
+	.field-map__map :global(.maplibregl-popup),
+	.field-map__map :global(.maplibregl-control-container) {
+		z-index: 2;
+	}
+
+	.field-map__caption {
+		margin: 0.75rem 0 0;
+		text-align: center;
+		font-family: var(--font-special-elite);
+		font-size: calc(var(--fs-xs) * 0.92);
+		letter-spacing: 0.02em;
+		color: color-mix(in oklab, var(--trail-ink) 65%, transparent);
+	}
+
+	/* MapLibre chrome */
+	.field-map__map :global(.maplibregl-ctrl-group) {
+		background: var(--trail-paper);
+		border: 1px solid color-mix(in oklab, var(--trail-rule) 65%, transparent);
+		border-radius: 2px;
+		box-shadow: 0 2px 8px rgba(40, 28, 12, 0.2);
+		overflow: hidden;
+	}
+
+	.field-map__map :global(.maplibregl-ctrl-group button) {
+		background: transparent;
+		border-color: color-mix(in oklab, var(--trail-rule) 35%, transparent);
+	}
+
+	.field-map__map :global(.maplibregl-ctrl-group button + button) {
+		border-top-color: color-mix(in oklab, var(--trail-rule) 35%, transparent);
+	}
+
+	.field-map__map :global(.maplibregl-ctrl-attrib) {
+		background: color-mix(in oklab, var(--trail-paper) 88%, transparent);
+		font-family: var(--font-special-elite);
+		font-size: 0.65rem;
+		color: var(--trail-ink);
+	}
+
+	.field-map__map :global(.maplibregl-ctrl-attrib a) {
+		color: var(--trail-pin-deep);
+	}
+
+	/* Custom pins — root must not use `transform` (MapLibre owns that). */
+	:global(.trail-pin) {
+		display: block;
+		width: 36px;
+		height: 40px;
+		padding: 0;
+		border: 0;
+		margin: 0;
+		background: transparent;
+		cursor: pointer;
+		line-height: 0;
+		overflow: visible;
+	}
+
+	:global(.trail-pin__lift) {
+		display: block;
+		width: 36px;
+		height: 40px;
+		line-height: 0;
+		filter: drop-shadow(0 2px 2px rgba(40, 28, 12, 0.4));
+		transition: translate 160ms ease;
+	}
+
+	:global(.trail-pin:hover .trail-pin__lift),
+	:global(.trail-pin:focus-visible .trail-pin__lift) {
+		translate: 0 -2px;
+	}
+
+	:global(.trail-pin:focus-visible) {
+		outline: none;
+	}
+
+	:global(.trail-pin__glyph) {
+		display: block;
+		overflow: visible;
+	}
+
+	:global(.trail-pin__body) {
+		fill: #8b2e24;
+		stroke: #5c1c16;
+		stroke-width: 1.25;
+	}
+
+	:global(.trail-pin__rim) {
+		fill: none;
+		stroke: #b8923c;
+		stroke-width: 2;
+	}
+
+	:global(.trail-pin__face) {
+		fill: #f3ead6;
+		stroke: #b8923c;
+		stroke-width: 1;
+	}
+
+	:global(.trail-pin__glint) {
+		fill: rgba(255, 255, 255, 0.55);
+	}
+
+	/* Field-note popup */
+	:global(.trail-popup-shell.maplibregl-popup) {
+		font-family: var(--font-special-elite);
+	}
+
+	:global(.trail-popup-shell .maplibregl-popup-content) {
+		padding: 0.85rem 0.95rem 0.95rem;
+		background:
+			linear-gradient(180deg, #f7f0e2 0%, var(--trail-paper, #efe6d4) 100%);
+		border: 1px solid color-mix(in oklab, var(--trail-rule, #8a7355) 70%, #3a3228);
+		border-radius: 2px;
+		box-shadow:
+			0 0 0 1px rgba(255, 248, 230, 0.45) inset,
+			0 10px 24px rgba(35, 24, 10, 0.28);
+		color: var(--trail-ink, #3a3228);
+	}
+
+	:global(.trail-popup-shell .maplibregl-popup-tip) {
+		border-top-color: var(--trail-paper, #efe6d4);
+	}
+
+	:global(.trail-popup-shell .maplibregl-popup-close-button) {
+		font-size: 1.1rem;
+		color: var(--trail-rule, #8a7355);
+		padding: 0.15rem 0.45rem;
+	}
+
+	:global(.trail-popup-shell .maplibregl-popup-close-button:hover) {
+		background: transparent;
+		color: var(--trail-pin-deep, #5c1c16);
+	}
+
+	:global(.trail-popup__rule) {
+		height: 1px;
+		margin: 0 0 0.55rem;
+		background: repeating-linear-gradient(
+			90deg,
+			color-mix(in oklab, var(--trail-rule, #8a7355) 75%, transparent) 0 6px,
+			transparent 6px 10px
+		);
+	}
+
+	:global(.trail-popup__rule--bottom) {
+		margin: 0.7rem 0 0;
+	}
+
+	:global(.trail-popup__title) {
+		font-family: var(--font-oswald);
+		font-size: 1.05rem;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		text-align: center;
+		color: var(--trail-ink, #3a3228);
+		margin-bottom: 0.45rem;
+	}
+
+	:global(.trail-popup__meta) {
+		text-align: center;
+		font-size: 0.78rem;
+		letter-spacing: 0.04em;
+		color: color-mix(in oklab, var(--trail-ink, #3a3228) 72%, transparent);
 		margin-bottom: 0.25rem;
 	}
 
-	:global(.popup-rating) {
-		font-size: var(--fs-base);
-		color: var(--color-secondary);
-		margin-bottom: 0.5rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.25rem;
+	:global(.trail-popup__meta span) {
+		color: var(--trail-pin-deep, #5c1c16);
 	}
 
-	:global(.popup-links) {
+	:global(.trail-popup__rating) {
+		text-align: center;
+		font-size: 1.25rem;
+		letter-spacing: 0.14em;
+		color: var(--trail-brass, #b8923c);
+		margin: 0.3rem 0 0.4rem;
+	}
+
+	:global(.trail-popup__links) {
 		display: flex;
 		flex-direction: column;
-		gap: 0.5rem;
-		margin-top: 0.75rem;
-		padding-top: 0.75rem;
-		border-top: 2px solid var(--color-tertiary-lighter);
+		gap: 0.4rem;
+		margin-top: 0.65rem;
+		padding-top: 0.55rem;
+		border-top: 1px solid color-mix(in oklab, var(--trail-rule, #8a7355) 45%, transparent);
 	}
 
-	:global(.popup-links a) {
-		font-size: var(--fs-xs);
-		color: var(--color-primary);
-		text-decoration: underline;
-		transition: color 0.2s ease;
+	:global(.trail-popup__link) {
+		display: block;
+		text-align: center;
+		font-size: 0.78rem;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		text-decoration: none;
+		color: var(--trail-pin-deep, #5c1c16);
+		border: 1px solid color-mix(in oklab, var(--trail-pin, #8b2e24) 45%, transparent);
+		padding: 0.35rem 0.5rem;
+		background: color-mix(in oklab, #fff8e8 55%, transparent);
+		transition:
+			background 0.15s ease,
+			border-color 0.15s ease;
 	}
 
-	:global(.popup-links a:hover) {
-		color: var(--color-primary-darker);
+	:global(.trail-popup__link:hover),
+	:global(.trail-popup__link:focus-visible) {
+		background: color-mix(in oklab, var(--trail-brass-light, #d4b56a) 35%, #fff8e8);
+		border-color: var(--trail-pin, #8b2e24);
+		outline: none;
+	}
+
+	@media (max-width: 640px) {
+		.field-map__map {
+			min-height: 480px;
+			height: 70vh;
+		}
 	}
 </style>

--- a/src/routes/(site)/projects/+page.svelte
+++ b/src/routes/(site)/projects/+page.svelte
@@ -457,14 +457,29 @@
 	}
 
 	.cms-edit-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.15rem 0.5rem;
+		border: 1px solid #8b0000;
+		border-radius: 3px;
+		background: transparent;
 		color: #8b0000;
 		text-decoration: none;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
 		font-size: calc(var(--fs-xs) * 0.85);
+		line-height: 1.2;
+		vertical-align: middle;
+		transition:
+			background 0.15s ease,
+			color 0.15s ease;
 
-		&:hover {
-			text-decoration: underline;
+		&:hover,
+		&:focus-visible {
+			background: #8b0000;
+			color: #f5f0e6;
+			text-decoration: none;
 		}
 	}
 

--- a/src/routes/api/gallery/albums/[albumId]/+server.ts
+++ b/src/routes/api/gallery/albums/[albumId]/+server.ts
@@ -1,6 +1,6 @@
 import { getMergedSessionUser } from '$lib/auth/requireAdmin.server';
 import { getPayloadSDK } from '$lib/payload/sdk.server';
-import { canAccessGallerySettings } from '$lib/utils/gallery-access';
+import { canAccessGallerySettings, mediaRequiresAuthProxy } from '$lib/utils/gallery-access';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -49,21 +49,26 @@ export const GET: RequestHandler = async (event) => {
 		depth: 0
 	});
 
-	const docs = (imagesResult.docs ?? []).map((doc) => ({
-		thumbnailURL: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? null,
-		id: doc.id,
-		blurhash: doc.blurhash ?? null,
-		width: doc.sizes?.thumbnail?.width ?? doc.width ?? null,
-		height: doc.sizes?.thumbnail?.height ?? doc.height ?? null,
-		url: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? doc.url ?? '',
-		sizes: {
-			thumbnail: {
-				url: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? null,
-				width: doc.sizes?.thumbnail?.width ?? null,
-				height: doc.sizes?.thumbnail?.height ?? null
+	const albumIsNsfw = album.settings?.isNsfw === true;
+	const docs = (imagesResult.docs ?? [])
+		.filter((doc) => canAccessGallerySettings(doc.settings, user))
+		.map((doc) => ({
+			thumbnailURL: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? null,
+			id: doc.id,
+			blurhash: doc.blurhash ?? null,
+			width: doc.sizes?.thumbnail?.width ?? doc.width ?? null,
+			height: doc.sizes?.thumbnail?.height ?? doc.height ?? null,
+			url: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? doc.url ?? '',
+			needsProxy: mediaRequiresAuthProxy(doc.settings) || albumIsNsfw,
+			isNsfw: doc.settings?.isNsfw === true || albumIsNsfw,
+			sizes: {
+				thumbnail: {
+					url: doc.sizes?.thumbnail?.url ?? doc.thumbnailURL ?? null,
+					width: doc.sizes?.thumbnail?.width ?? null,
+					height: doc.sizes?.thumbnail?.height ?? null
+				}
 			}
-		}
-	}));
+		}));
 
 	return json({
 		docs,

--- a/src/routes/api/gallery/albums/[albumId]/paged/+server.ts
+++ b/src/routes/api/gallery/albums/[albumId]/paged/+server.ts
@@ -61,14 +61,23 @@ export const GET: RequestHandler = async (event) => {
 						width: true,
 						height: true,
 						blurhash: true,
-						settings: { isNsfw: true }
+						settings: {
+							isNsfw: true,
+							visibility: true,
+							permittedRoles: true,
+							allowedUsers: true
+						}
 					}
 				}
 			: {})
 	});
 
+	const docs = (imagesResult.docs ?? []).filter((doc) =>
+		canAccessGallerySettings(doc.settings, user)
+	);
+
 	return json({
-		docs: imagesResult.docs ?? [],
+		docs,
 		page: imagesResult.page,
 		nextPage: imagesResult.nextPage,
 		hasNextPage: imagesResult.hasNextPage,

--- a/src/routes/api/gallery/images/[id]/+server.ts
+++ b/src/routes/api/gallery/images/[id]/+server.ts
@@ -2,7 +2,7 @@ import { getMergedSessionUser } from '$lib/auth/requireAdmin.server';
 import { getPayloadSDK } from '$lib/payload/sdk.server';
 import { getStoreConfig, getStoreProduct } from '$lib/medusa/store.server';
 import type { GalleryImage } from '$lib/types/payload-types';
-import { canAccessGallerySettings } from '$lib/utils/gallery-access';
+import { canAccessGallerySettings, mediaRequiresAuthProxy } from '$lib/utils/gallery-access';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -84,6 +84,9 @@ export const GET: RequestHandler = async (event) => {
 		width: isGif ? (doc.width ?? null) : (doc.sizes?.thumbnail?.width ?? doc.width ?? null),
 		height: isGif ? (doc.height ?? null) : (doc.sizes?.thumbnail?.height ?? doc.height ?? null),
 		url: previewUrl,
+		/** Client uses this to route restricted bytes through `/api/media-proxy`. */
+		needsProxy: mediaRequiresAuthProxy(doc.settings),
+		isNsfw: doc.settings?.isNsfw === true,
 		sizes: isGif
 			? {}
 			: {


### PR DESCRIPTION
## Summary
- Gallery lightbox: custom zoom/pan, persist hide-details preference, neighbor image preload, Admin tab + CMS edit affordances
- Restricted gallery media: per-image auth proxy so privileged images load for admins
- CMS “Edit in CMS” controls restyled as buttons across articles, models, projects, and galleries
- Parks & Hikes: vintage trail-ledger map chrome, custom pins, stats plate under a taller map

## Test plan
- [ ] Open a public gallery album; lightbox next/prev feels snappy; hide details persists after reload
- [ ] As admin, open a restricted/NSFW image in a public album and confirm it loads (proxy)
- [ ] Confirm Edit in CMS buttons on album header, lightbox Admin tab, article, model, and project pages
- [ ] Visit `/parks-and-hikes`: map tiles + pins align, popups work, ledger stats look correct
- [ ] `pnpm run check` / smoke `pnpm run dev`


Made with [Cursor](https://cursor.com)