### PR TITLE
Ship crisp canvas zoom and fix lightbox hydration (v0.25.0).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "www-itsmillertime-dev",
 	"private": true,
-	"version": "0.24.0",
+	"version": "0.25.0",
 	"type": "module",
 	"scripts": {
 		"dev": "pnpm run fetch-payload-types && vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -24,7 +24,7 @@
 		<!--
 			Must stay inline in HTML (not a module): an old service worker was cache-firsting
 			client bundles, so SSR painted the correct blog list and then stale JS hydrated
-			over it. This runs before %sveltekit.body% modules and clears that once.
+			over it. This runs before the SvelteKit body mount and clears that once.
 		-->
 		<script>
 			(function () {

--- a/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
+++ b/src/lib/components/gallery/GalleryLightboxContent/GalleryLightboxContent.svelte
@@ -17,7 +17,12 @@
 	import { preventContextMenu } from '$lib/utils/prevent-context-menu';
 	import { lexicalToPlainText } from '$lib/utils/lexical-to-text';
 	import { getMediaUrl, isVideoMedia } from '$lib/utils/media-url';
-	import { imageZoomPan, type ImageZoomPanHandle } from '$lib/utils/image-zoom-pan';
+	import { imageZoomPan, type ImageZoomPanHandle, type ImageZoomPanTransform } from '$lib/utils/image-zoom-pan';
+	import {
+		createLightboxZoomCanvasController,
+		type LightboxZoomCanvasPaintInput
+	} from '$lib/utils/lightbox-zoom-canvas';
+	import { disposeZoomBitmap, loadZoomBitmap } from '$lib/utils/lightbox-zoom-source';
 	import ExifIcon from '$lib/components/ExifIcon';
 	import GalleryMediaPlayer from '$lib/components/gallery/GalleryMediaPlayer';
 	import BuyButton from '$lib/components/commerce/BuyButton.svelte';
@@ -52,7 +57,12 @@
 
 	let activeSidebarTab = $state<SidebarTab>('information');
 	/** When true, hide the details panel so the image fills the viewport. */
-	let infoCollapsed = $state(readInfoCollapsedPref());
+	let infoCollapsed = $state(false);
+
+	$effect(() => {
+		if (!browser) return;
+		infoCollapsed = readInfoCollapsedPref();
+	});
 
 	function toggleInfoPanel() {
 		infoCollapsed = !infoCollapsed;
@@ -114,8 +124,27 @@
 	let imageZoomed = $state(false);
 	let imagePaneEl = $state<HTMLDivElement | null>(null);
 	let imageFrameEl = $state<HTMLDivElement | null>(null);
+	let zoomCanvasEl = $state<HTMLCanvasElement | null>(null);
+	let mainImageEl = $state<HTMLImageElement | null>(null);
 	/** Scale needed for the image frame to cover the full image pane (fills letterbox bars). */
 	let coverScale = $state(1);
+	let zoomTransform = $state<ImageZoomPanTransform>({ scale: 1, tx: 0, ty: 0 });
+	let zoomBitmap = $state<ImageBitmap | null>(null);
+	let zoomBitmapLoading = $state(false);
+	let zoomBitmapFailed = $state(false);
+	let heldZoomBitmap: ImageBitmap | null = null;
+	let zoomCanvasController: ReturnType<typeof createLightboxZoomCanvasController> | null = null;
+
+	/** Canvas owns pixels once bitmap is ready and user is zoomed; CSS transform remains for hit-testing. */
+	const sharpZoomActive = $derived(imageZoomed && zoomBitmap != null);
+
+	function setZoomBitmap(next: ImageBitmap | null) {
+		if (heldZoomBitmap && heldZoomBitmap !== next) {
+			disposeZoomBitmap(heldZoomBitmap);
+		}
+		heldZoomBitmap = next;
+		zoomBitmap = next;
+	}
 
 	function measureCoverScale() {
 		const pane = imagePaneEl;
@@ -129,6 +158,40 @@
 		coverScale = Math.max(1, paneW / frameW, paneH / frameH);
 	}
 
+	function ensureZoomBitmap() {
+		if (!browser || !resolvedImageSrc || zoomBitmap || zoomBitmapLoading || zoomBitmapFailed) return;
+		const src = resolvedImageSrc;
+		const imgEl = mainImageEl;
+		zoomBitmapLoading = true;
+		void loadZoomBitmap(src, imgEl)
+			.then((bitmap) => {
+				if (resolvedImageSrc !== src) {
+					disposeZoomBitmap(bitmap);
+					return;
+				}
+				setZoomBitmap(bitmap);
+				zoomBitmapFailed = false;
+				zoomCanvasController?.schedule();
+			})
+			.catch(() => {
+				if (resolvedImageSrc === src) zoomBitmapFailed = true;
+			})
+			.finally(() => {
+				if (resolvedImageSrc === src) zoomBitmapLoading = false;
+			});
+	}
+
+	function onZoomChange(z: boolean) {
+		imageZoomed = z;
+		if (z) ensureZoomBitmap();
+	}
+
+	function onZoomTransform(t: ImageZoomPanTransform) {
+		zoomTransform = t;
+		if (t.scale > 1.001) ensureZoomBitmap();
+		zoomCanvasController?.schedule();
+	}
+
 	$effect(() => {
 		if (!browser) return;
 		void index;
@@ -138,7 +201,10 @@
 		const pane = imagePaneEl;
 		const frame = imageFrameEl;
 		if (!pane || !frame) return;
-		const ro = new ResizeObserver(() => measureCoverScale());
+		const ro = new ResizeObserver(() => {
+			measureCoverScale();
+			zoomCanvasController?.schedule();
+		});
 		ro.observe(pane);
 		ro.observe(frame);
 		return () => ro.disconnect();
@@ -147,10 +213,50 @@
 	const imageZoomPanOptions = $derived({
 		handle: zoomHandle,
 		maxScale: Math.max(coverScale * 4, 8),
-		clickZoomScale: coverScale > 1.01 ? coverScale : 2.5,
-		onZoomChange: (z: boolean) => {
-			imageZoomed = z;
-		}
+		// Progressive zoom — do not snap to coverScale (that felt like a horizontal stretch
+		// when details are collapsed and side letterbars are large). Bars still fill as scale grows.
+		clickZoomScale: 2.5,
+		// Keep CSS transform so the frame's hit region scales with zoom; canvas paints sharp pixels on top.
+		applyCssTransform: true,
+		onZoomChange,
+		onTransform: onZoomTransform
+	});
+
+	$effect(() => {
+		if (!browser) return;
+		zoomCanvasController = createLightboxZoomCanvasController(() => {
+			const canvas = zoomCanvasEl;
+			const pane = imagePaneEl;
+			const frame = imageFrameEl;
+			const bitmap = zoomBitmap;
+			if (!canvas || !pane || !frame || !bitmap) return null;
+			if (zoomTransform.scale <= 1.001) return null;
+			const input: LightboxZoomCanvasPaintInput = {
+				canvas,
+				pane,
+				frame,
+				bitmap,
+				transform: zoomTransform
+			};
+			return input;
+		});
+		return () => {
+			zoomCanvasController?.destroy();
+			zoomCanvasController = null;
+		};
+	});
+
+	$effect(() => {
+		if (!browser) return;
+		void index;
+		void resolvedImageSrc;
+		setZoomBitmap(null);
+		zoomBitmapLoading = false;
+		zoomBitmapFailed = false;
+		zoomTransform = { scale: 1, tx: 0, ty: 0 };
+		return () => {
+			setZoomBitmap(null);
+		};
 	});
 
 	/** Blurhash (or parent-passed placeholder string) for underlay while full image loads */
@@ -199,6 +305,28 @@
 		void resolvedImageSrc;
 		zoomHandle.reset();
 		imageZoomed = false;
+	});
+
+	/** Idle-prefetch bitmap after the lightbox img is ready. */
+	$effect(() => {
+		if (!browser || !mainImageLoaded || !resolvedImageSrc || zoomBitmap || zoomBitmapFailed) return;
+		const src = resolvedImageSrc;
+		const ric = window.requestIdleCallback?.bind(window);
+		if (ric) {
+			const id = ric(() => {
+				if (resolvedImageSrc === src) ensureZoomBitmap();
+			}, { timeout: 1500 });
+			return () => window.cancelIdleCallback?.(id);
+		}
+		const t = setTimeout(() => {
+			if (resolvedImageSrc === src) ensureZoomBitmap();
+		}, 400);
+		return () => clearTimeout(t);
+	});
+
+	$effect(() => {
+		if (!sharpZoomActive) return;
+		zoomCanvasController?.schedule();
 	});
 
 	/**
@@ -499,6 +627,13 @@
 				type="button"
 			></button>
 
+			<canvas
+				class="gallery-lightbox__zoom-canvas"
+				class:gallery-lightbox__zoom-canvas--active={sharpZoomActive}
+				bind:this={zoomCanvasEl}
+				aria-hidden="true"
+			></canvas>
+
 			<button
 				class="gallery-lightbox__close"
 				onclick={(e) => {
@@ -597,6 +732,8 @@
 						{#key index}
 							<img
 								class="gallery-lightbox__image"
+								class:gallery-lightbox__image--sharp-hidden={sharpZoomActive}
+								bind:this={mainImageEl}
 								use:mainLightboxImage
 								src={resolvedImageSrc ?? ''}
 								alt={image?.alt ?? ''}
@@ -1091,7 +1228,22 @@
 		justify-content: center;
 		min-width: 0;
 		overflow: hidden;
+		container-type: size;
 		transition: flex-basis 220ms ease;
+	}
+
+	.gallery-lightbox__zoom-canvas {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		opacity: 0;
+	}
+
+	.gallery-lightbox__zoom-canvas--active {
+		opacity: 1;
 	}
 
 	.gallery-lightbox__backdrop {
@@ -1142,11 +1294,15 @@
 
 	.gallery-lightbox__image-frame {
 		position: relative;
-		width: 100%;
+		/* Explicit contain-fit in the pane so the box always matches image aspect
+		   (width:100% / height:100% alone distort when the other axis clamps). */
+		--_ar: var(--image-aspect-ratio, 1);
+		width: min(100cqw, calc(100cqh * var(--_ar)));
+		height: min(100cqh, calc(100cqw / var(--_ar)));
 		max-width: 100%;
 		max-height: 100%;
 		overflow: hidden;
-		z-index: 1;
+		z-index: 2;
 		pointer-events: none;
 		flex-shrink: 0;
 	}
@@ -1249,6 +1405,10 @@
 		pointer-events: none;
 		transition: opacity 300ms ease;
 		animation: imageFadeIn 180ms ease;
+	}
+
+	.gallery-lightbox__image--sharp-hidden {
+		visibility: hidden;
 	}
 
 	.gallery-lightbox__image-frame :global(.gallery-lightbox__video) {

--- a/src/lib/utils/image-zoom-pan.ts
+++ b/src/lib/utils/image-zoom-pan.ts
@@ -3,6 +3,12 @@ export type ImageZoomPanHandle = {
 	isZoomed: () => boolean;
 };
 
+export type ImageZoomPanTransform = {
+	scale: number;
+	tx: number;
+	ty: number;
+};
+
 export type ImageZoomPanOptions = {
 	minScale?: number;
 	maxScale?: number;
@@ -12,6 +18,13 @@ export type ImageZoomPanOptions = {
 	handle?: ImageZoomPanHandle;
 	/** Fired when zoomed-in state toggles (scale > 1). */
 	onZoomChange?: (zoomed: boolean) => void;
+	/** Fired whenever scale/translate are applied (including identity). */
+	onTransform?: (t: ImageZoomPanTransform) => void;
+	/**
+	 * When false, skip writing CSS transform on the node (canvas owns pixels).
+	 * Hit-testing still uses the node; keep true if the node must grow with scale.
+	 */
+	applyCssTransform?: boolean;
 };
 
 type Point = { x: number; y: number };
@@ -27,6 +40,8 @@ export function imageZoomPan(node: HTMLElement, options: ImageZoomPanOptions = {
 	let maxScale = options.maxScale ?? 5;
 	let clickZoomScale = options.clickZoomScale ?? 2.5;
 	let onZoomChange = options.onZoomChange;
+	let onTransform = options.onTransform;
+	let applyCssTransform = options.applyCssTransform ?? true;
 	let handle = options.handle;
 
 	let scale = 1;
@@ -59,10 +74,16 @@ export function imageZoomPan(node: HTMLElement, options: ImageZoomPanOptions = {
 
 	function apply() {
 		node.style.transformOrigin = 'center center';
-		node.style.transform = `translate3d(${tx}px, ${ty}px, 0) scale(${scale})`;
-		node.style.willChange = scale > 1 || tx !== 0 || ty !== 0 ? 'transform' : 'auto';
+		if (applyCssTransform) {
+			node.style.transform = `translate3d(${tx}px, ${ty}px, 0) scale(${scale})`;
+			node.style.willChange = scale > 1 || tx !== 0 || ty !== 0 ? 'transform' : 'auto';
+		} else {
+			node.style.transform = '';
+			node.style.willChange = 'auto';
+		}
 		node.style.cursor = scale > 1.001 ? (dragging ? 'grabbing' : 'grab') : 'zoom-in';
 		setZoomed(scale > 1.001);
+		onTransform?.({ scale, tx, ty });
 	}
 
 	function clampPan() {
@@ -343,11 +364,17 @@ export function imageZoomPan(node: HTMLElement, options: ImageZoomPanOptions = {
 			maxScale = next.maxScale ?? 5;
 			clickZoomScale = next.clickZoomScale ?? 2.5;
 			onZoomChange = next.onZoomChange;
+			onTransform = next.onTransform;
+			const nextApplyCss = next.applyCssTransform ?? true;
+			const cssModeChanged = nextApplyCss !== applyCssTransform;
+			applyCssTransform = nextApplyCss;
 			handle = next.handle;
 			bindHandle();
 			if (scale < minScale || scale > maxScale) {
 				scale = Math.min(maxScale, Math.max(minScale, scale));
 				clampPan();
+				apply();
+			} else if (cssModeChanged) {
 				apply();
 			}
 		},

--- a/src/lib/utils/lightbox-zoom-canvas.test.ts
+++ b/src/lib/utils/lightbox-zoom-canvas.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { containRect, paintLightboxZoomCanvas } from './lightbox-zoom-canvas';
+
+describe('containRect', () => {
+	it('letterboxes horizontally when the box is wider than the image', () => {
+		// 2:1 box, 1:1 image → image height-fills, x inset
+		const r = containRect(400, 200, 1000, 1000);
+		expect(r.h).toBe(200);
+		expect(r.w).toBe(200);
+		expect(r.x).toBe(100);
+		expect(r.y).toBe(0);
+	});
+
+	it('letterboxes vertically when the box is taller than the image', () => {
+		const r = containRect(200, 400, 1000, 1000);
+		expect(r.w).toBe(200);
+		expect(r.h).toBe(200);
+		expect(r.x).toBe(0);
+		expect(r.y).toBe(100);
+	});
+});
+
+describe('paintLightboxZoomCanvas', () => {
+	it('draws the visible crop when zoomed', () => {
+		const drawImage = vi.fn();
+		const clearRect = vi.fn();
+		const setTransform = vi.fn();
+		const ctx = {
+			drawImage,
+			clearRect,
+			setTransform,
+			imageSmoothingEnabled: false,
+			imageSmoothingQuality: 'low'
+		};
+
+		const canvas = {
+			width: 0,
+			height: 0,
+			getContext: () => ctx
+		} as unknown as HTMLCanvasElement;
+
+		const pane = { clientWidth: 400, clientHeight: 800 } as HTMLElement;
+		const frame = { offsetWidth: 400, offsetHeight: 600 } as HTMLElement;
+		const bitmap = { width: 4000, height: 6000 } as ImageBitmap;
+
+		vi.stubGlobal('window', { devicePixelRatio: 2 });
+
+		paintLightboxZoomCanvas({
+			canvas,
+			pane,
+			frame,
+			bitmap,
+			transform: { scale: 2, tx: 0, ty: 0 }
+		});
+
+		expect(canvas.width).toBe(800);
+		expect(canvas.height).toBe(1600);
+		expect(setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+		expect(clearRect).toHaveBeenCalled();
+		expect(drawImage).toHaveBeenCalled();
+		const args = drawImage.mock.calls[0];
+		expect(args[0]).toBe(bitmap);
+		expect(args[3]).toBeGreaterThan(0);
+		expect(args[4]).toBeGreaterThan(0);
+		expect(args[3]).toBeLessThanOrEqual(bitmap.width);
+		expect(args[4]).toBeLessThanOrEqual(bitmap.height);
+
+		vi.unstubAllGlobals();
+	});
+
+	it('does not stretch when the frame is wider than the bitmap aspect', () => {
+		const drawImage = vi.fn();
+		const canvas = {
+			width: 0,
+			height: 0,
+			getContext: () => ({
+				drawImage,
+				clearRect: vi.fn(),
+				setTransform: vi.fn(),
+				imageSmoothingEnabled: false,
+				imageSmoothingQuality: 'low'
+			})
+		} as unknown as HTMLCanvasElement;
+
+		vi.stubGlobal('window', { devicePixelRatio: 1 });
+
+		// Distorted 2:1 frame with square bitmap — contain letterboxes; source/dest aspects must match.
+		paintLightboxZoomCanvas({
+			canvas,
+			pane: { clientWidth: 800, clientHeight: 400 } as HTMLElement,
+			frame: { offsetWidth: 800, offsetHeight: 400 } as HTMLElement,
+			bitmap: { width: 2000, height: 2000 } as ImageBitmap,
+			transform: { scale: 1.5, tx: 0, ty: 0 }
+		});
+
+		expect(drawImage).toHaveBeenCalled();
+		const [, sx, sy, sw, sh, dx, dy, dw, dh] = drawImage.mock.calls[0];
+		// Non-stretch: source crop aspect must match destination (contain), not map a square
+		// bitmap into a 2:1 frame (which would yield sw/sh ≈ 1 with dw/dh ≈ 2).
+		expect(sw / sh).toBeCloseTo(dw / dh, 5);
+		expect(Math.abs(sw / sh - dw / dh)).toBeLessThan(0.01);
+		void sx;
+		void sy;
+		void dx;
+		void dy;
+
+		vi.unstubAllGlobals();
+	});
+
+	it('skips drawing at identity scale', () => {
+		const drawImage = vi.fn();
+		const canvas = {
+			width: 0,
+			height: 0,
+			getContext: () => ({
+				drawImage,
+				clearRect: vi.fn(),
+				setTransform: vi.fn(),
+				imageSmoothingEnabled: false,
+				imageSmoothingQuality: 'low'
+			})
+		} as unknown as HTMLCanvasElement;
+
+		paintLightboxZoomCanvas({
+			canvas,
+			pane: { clientWidth: 400, clientHeight: 800 } as HTMLElement,
+			frame: { offsetWidth: 400, offsetHeight: 600 } as HTMLElement,
+			bitmap: { width: 4000, height: 6000 } as ImageBitmap,
+			transform: { scale: 1, tx: 0, ty: 0 }
+		});
+
+		expect(drawImage).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/utils/lightbox-zoom-canvas.ts
+++ b/src/lib/utils/lightbox-zoom-canvas.ts
@@ -1,0 +1,132 @@
+import type { ImageZoomPanTransform } from '$lib/utils/image-zoom-pan';
+
+export type LightboxZoomCanvasPaintInput = {
+	canvas: HTMLCanvasElement;
+	pane: HTMLElement;
+	frame: HTMLElement;
+	bitmap: ImageBitmap;
+	transform: ImageZoomPanTransform;
+};
+
+/** object-fit: contain rect of an image inside a box (CSS pixels). */
+export function containRect(
+	boxW: number,
+	boxH: number,
+	imgW: number,
+	imgH: number
+): { x: number; y: number; w: number; h: number } {
+	if (boxW <= 0 || boxH <= 0 || imgW <= 0 || imgH <= 0) {
+		return { x: 0, y: 0, w: boxW, h: boxH };
+	}
+	const boxAr = boxW / boxH;
+	const imgAr = imgW / imgH;
+	if (imgAr > boxAr) {
+		const w = boxW;
+		const h = boxW / imgAr;
+		return { x: 0, y: (boxH - h) / 2, w, h };
+	}
+	const h = boxH;
+	const w = boxH * imgAr;
+	return { x: (boxW - w) / 2, y: 0, w, h };
+}
+
+/**
+ * Paint the visible crop of `bitmap` into a pane-sized canvas, matching
+ * center-origin translate+scale used by imageZoomPan on the aspect-ratio frame,
+ * with object-fit:contain of the bitmap inside that frame (same as the <img>).
+ */
+export function paintLightboxZoomCanvas(input: LightboxZoomCanvasPaintInput): void {
+	const { canvas, pane, frame, bitmap, transform } = input;
+	const { scale, tx, ty } = transform;
+
+	const paneW = pane.clientWidth;
+	const paneH = pane.clientHeight;
+	if (paneW <= 0 || paneH <= 0) return;
+
+	const frameW = frame.offsetWidth;
+	const frameH = frame.offsetHeight;
+	if (frameW <= 0 || frameH <= 0) return;
+
+	const dpr = Math.max(
+		1,
+		(typeof window !== 'undefined' ? window.devicePixelRatio : undefined) || 1
+	);
+	const bufW = Math.max(1, Math.round(paneW * dpr));
+	const bufH = Math.max(1, Math.round(paneH * dpr));
+	if (canvas.width !== bufW || canvas.height !== bufH) {
+		canvas.width = bufW;
+		canvas.height = bufH;
+	}
+
+	const ctx = canvas.getContext('2d');
+	if (!ctx) return;
+
+	ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+	ctx.clearRect(0, 0, paneW, paneH);
+
+	if (scale <= 1.001) return;
+
+	// Image content box inside the frame (object-fit: contain), then CSS transform.
+	const fitted = containRect(frameW, frameH, bitmap.width, bitmap.height);
+	const destX = paneW / 2 - (frameW / 2) * scale + tx + fitted.x * scale;
+	const destY = paneH / 2 - (frameH / 2) * scale + ty + fitted.y * scale;
+	const destW = fitted.w * scale;
+	const destH = fitted.h * scale;
+
+	const visibleLeft = Math.max(0, destX);
+	const visibleTop = Math.max(0, destY);
+	const visibleRight = Math.min(paneW, destX + destW);
+	const visibleBottom = Math.min(paneH, destY + destH);
+	if (visibleRight <= visibleLeft || visibleBottom <= visibleTop) return;
+
+	const sx = ((visibleLeft - destX) / destW) * bitmap.width;
+	const sy = ((visibleTop - destY) / destH) * bitmap.height;
+	const sw = ((visibleRight - visibleLeft) / destW) * bitmap.width;
+	const sh = ((visibleBottom - visibleTop) / destH) * bitmap.height;
+	if (sw <= 0 || sh <= 0) return;
+
+	ctx.imageSmoothingEnabled = true;
+	ctx.imageSmoothingQuality = 'high';
+	ctx.drawImage(
+		bitmap,
+		sx,
+		sy,
+		sw,
+		sh,
+		visibleLeft,
+		visibleTop,
+		visibleRight - visibleLeft,
+		visibleBottom - visibleTop
+	);
+}
+
+export type LightboxZoomCanvasController = {
+	schedule: () => void;
+	destroy: () => void;
+};
+
+/** Coalesce paints to at most one drawImage per animation frame. */
+export function createLightboxZoomCanvasController(
+	getInput: () => LightboxZoomCanvasPaintInput | null
+): LightboxZoomCanvasController {
+	let raf = 0;
+
+	const schedule = () => {
+		if (raf) return;
+		raf = requestAnimationFrame(() => {
+			raf = 0;
+			const input = getInput();
+			if (!input) return;
+			paintLightboxZoomCanvas(input);
+		});
+	};
+
+	const destroy = () => {
+		if (raf) {
+			cancelAnimationFrame(raf);
+			raf = 0;
+		}
+	};
+
+	return { schedule, destroy };
+}

--- a/src/lib/utils/lightbox-zoom-source.ts
+++ b/src/lib/utils/lightbox-zoom-source.ts
@@ -1,0 +1,102 @@
+const FALLBACK_MAX_LONG_EDGE = 4096;
+
+/** Probe WebGL MAX_TEXTURE_SIZE; fall back to a conventional mobile heuristic. */
+export function getMaxTextureSize(): number {
+	if (typeof document === 'undefined') return FALLBACK_MAX_LONG_EDGE;
+	try {
+		const canvas = document.createElement('canvas');
+		const gl =
+			(canvas.getContext('webgl') as WebGLRenderingContext | null) ||
+			(canvas.getContext('experimental-webgl') as WebGLRenderingContext | null);
+		if (!gl) return FALLBACK_MAX_LONG_EDGE;
+		const size = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+		gl.getExtension('WEBGL_lose_context')?.loseContext();
+		return typeof size === 'number' && size > 0 ? size : FALLBACK_MAX_LONG_EDGE;
+	} catch {
+		return FALLBACK_MAX_LONG_EDGE;
+	}
+}
+
+function resizeOptionsForLongEdge(
+	width: number,
+	height: number,
+	maxLongEdge: number
+): ImageBitmapOptions | undefined {
+	const longEdge = Math.max(width, height);
+	if (longEdge <= maxLongEdge) return undefined;
+	const scale = maxLongEdge / longEdge;
+	return {
+		resizeWidth: Math.max(1, Math.round(width * scale)),
+		resizeHeight: Math.max(1, Math.round(height * scale)),
+		resizeQuality: 'high'
+	};
+}
+
+async function createBitmapFromBlobCapped(blob: Blob, maxLongEdge: number): Promise<ImageBitmap> {
+	const bitmap = await createImageBitmap(blob);
+	const opts = resizeOptionsForLongEdge(bitmap.width, bitmap.height, maxLongEdge);
+	if (!opts) return bitmap;
+	try {
+		const resized = await createImageBitmap(bitmap, opts);
+		bitmap.close();
+		return resized;
+	} catch {
+		bitmap.close();
+		// Some engines want resize options on the blob decode directly.
+		return createImageBitmap(blob, opts);
+	}
+}
+
+/**
+ * Decode a zoom source ImageBitmap from a URL (fetch → blob).
+ * On failure, optionally fall back to an already-loaded HTMLImageElement.
+ * If full-res decode throws, retries once capped to device max texture size.
+ */
+export async function loadZoomBitmap(
+	src: string,
+	fallbackImg?: HTMLImageElement | null
+): Promise<ImageBitmap> {
+	const maxLongEdge = getMaxTextureSize();
+
+	const tryFromImg = async (): Promise<ImageBitmap | null> => {
+		if (!fallbackImg || !fallbackImg.naturalWidth) return null;
+		try {
+			return await createImageBitmap(fallbackImg);
+		} catch {
+			try {
+				const opts = resizeOptionsForLongEdge(
+					fallbackImg.naturalWidth,
+					fallbackImg.naturalHeight,
+					maxLongEdge
+				);
+				return opts ? await createImageBitmap(fallbackImg, opts) : null;
+			} catch {
+				return null;
+			}
+		}
+	};
+
+	try {
+		const res = await fetch(src, { mode: 'cors', credentials: 'same-origin' });
+		if (!res.ok) throw new Error(`zoom bitmap fetch failed: ${res.status}`);
+		const blob = await res.blob();
+		try {
+			return await createImageBitmap(blob);
+		} catch {
+			return await createBitmapFromBlobCapped(blob, maxLongEdge);
+		}
+	} catch {
+		const fromImg = await tryFromImg();
+		if (fromImg) return fromImg;
+		throw new Error('Unable to decode zoom ImageBitmap');
+	}
+}
+
+export function disposeZoomBitmap(bitmap: ImageBitmap | null | undefined) {
+	if (!bitmap) return;
+	try {
+		bitmap.close();
+	} catch {
+		/* already closed */
+	}
+}

--- a/src/routes/(site)/+layout.ts
+++ b/src/routes/(site)/+layout.ts
@@ -1,4 +1,3 @@
-import { browser } from '$app/environment';
 import { loadSession } from '$lib/auth/loadSession';
 import type { LayoutCacheData } from '$lib/cache/layoutCache';
 import type { LayoutLoad } from './$types';
@@ -14,13 +13,10 @@ export const load: LayoutLoad = async (event) => {
 	};
 	const request = 'request' in event ? (event.request as Request) : undefined;
 
-	// Client: always refresh session (e.g. after login). SSR: reuse server layout.
-	const session = browser
-		? await loadSession(event.fetch, request)
-		: (parentData.session ?? (await loadSession(event.fetch, request)));
-
-	// SSR seed comes from +layout.server.ts (fetched in parallel with session).
-	const initialLayout = browser ? null : (parentData.initialLayout ?? null);
+	// Prefer SSR-serialized values so the client universal load matches server HTML during hydration.
+	// (Re-fetching session / nulling layout on browser caused root hydration_mismatch in SiteChrome.)
+	const session = parentData.session ?? (await loadSession(event.fetch, request));
+	const initialLayout = parentData.initialLayout ?? null;
 
 	return { session, initialLayout };
 };


### PR DESCRIPTION
Decode originals into an ImageBitmap and paint a viewport canvas while zoomed, keep aspect-correct framing when details are collapsed, and stop app.html from replacing %sveltekit.body% inside a comment.